### PR TITLE
[CHORE] Global interceptors, filters & rate limiting

### DIFF
--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -510,7 +510,7 @@ Structured JSON logging via NestJS built-in Logger (or `pino` for production per
   "timestamp": "2026-04-25T10:00:00.000Z",
   "context": "ApplicationService",
   "message": "Application created",
-  "correlationId": "req-uuid-v4",
+  "correlationId": "req-uuid-v7",
   "userId": "user-uuid"
 }
 ```
@@ -526,7 +526,7 @@ Structured JSON logging via NestJS built-in Logger (or `pino` for production per
 
 ### 14.3 Correlation ID
 
-Every HTTP request is assigned a unique `X-Correlation-ID` (UUID v4), injected by a global interceptor and propagated across all log entries for distributed tracing.
+Every HTTP request is assigned a unique `X-Correlation-ID` (UUID v7), injected by a global interceptor and propagated across all log entries for distributed tracing.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/terminus": "^11.1.1",
+        "@nestjs/throttler": "^6.5.0",
         "@prisma/client": "^6.19.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
@@ -2518,6 +2519,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/terminus": "^11.1.1",
+    "@nestjs/throttler": "^6.5.0",
     "@prisma/client": "^6.19.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,12 +1,15 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { validate } from './config/env.config';
 import { PrismaModule } from './prisma/prisma.module';
 import { HealthModule } from './modules/health/health.module';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
+import { CustomThrottlerGuard } from './common/guards/throttler.guard';
+import { THROTTLER_LIMITS } from './common/constants/throttler.constants';
 
 @Module({
   imports: [
@@ -14,6 +17,12 @@ import { TransformInterceptor } from './common/interceptors/transform.intercepto
       isGlobal: true,
       validate,
     }),
+    ThrottlerModule.forRoot([
+      {
+        limit: THROTTLER_LIMITS.global.limit,
+        ttl: THROTTLER_LIMITS.global.ttl,
+      },
+    ]),
     PrismaModule,
     HealthModule,
   ],
@@ -21,6 +30,7 @@ import { TransformInterceptor } from './common/interceptors/transform.intercepto
   providers: [
     AppService,
     { provide: APP_INTERCEPTOR, useClass: TransformInterceptor },
+    { provide: APP_GUARD, useClass: CustomThrottlerGuard },
   ],
 })
 export class AppModule {}

--- a/src/common/constants/throttler.constants.ts
+++ b/src/common/constants/throttler.constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Throttler limits per route group. See SysDesign §11.2.
+ *
+ * Only `global` is registered in ThrottlerModule.forRoot as the unnamed
+ * default throttler (100 req/min fallback). Routes that need a stricter
+ * cap override it with @Throttle({ default: { limit, ttl } }).
+ */
+export const THROTTLER_LIMITS = {
+  /** Global fallback — 100 req/min */
+  global: { ttl: 60_000, limit: 100 },
+  /** Strict — 5 req/min (e.g. POST /users, POST /authentications) */
+  strict: { ttl: 60_000, limit: 5 },
+  /** Moderate — 10 req/min (e.g. PUT /authentications, POST /documents) */
+  moderate: { ttl: 60_000, limit: 10 },
+} as const;
+
+export type ThrottlerLimitName = keyof typeof THROTTLER_LIMITS;

--- a/src/common/guards/throttler.guard.spec.ts
+++ b/src/common/guards/throttler.guard.spec.ts
@@ -1,0 +1,75 @@
+import { HttpException, HttpStatus, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ThrottlerStorageService } from '@nestjs/throttler';
+import { CustomThrottlerGuard } from './throttler.guard';
+
+describe('CustomThrottlerGuard', () => {
+  let guard: CustomThrottlerGuard;
+
+  beforeEach(() => {
+    guard = new CustomThrottlerGuard(
+      { throttlers: [{ ttl: 60_000, limit: 100 }] },
+      new ThrottlerStorageService(),
+      new Reflector(),
+    );
+  });
+
+  describe('throwThrottlingException', () => {
+    it('throws HttpException with 429 status and "Too Many Requests" message', async () => {
+      const context = {} as ExecutionContext;
+      const detail = {
+        ttl: 60_000,
+        limit: 100,
+        key: 'k',
+        tracker: 't',
+        totalHits: 101,
+        timeToExpire: 30,
+        isBlocked: false,
+        timeToBlockExpire: 0,
+      };
+
+      await expect(
+        // @ts-expect-error — accessing protected method for unit test
+        guard.throwThrottlingException(context, detail),
+      ).rejects.toThrow(HttpException);
+
+      try {
+        // @ts-expect-error — accessing protected method for unit test
+        await guard.throwThrottlingException(context, detail);
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpException);
+        const httpErr = err as HttpException;
+        expect(httpErr.getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
+        expect(httpErr.message).toBe('Too Many Requests');
+      }
+    });
+
+    it('produces the FailResponse shape via AllExceptionsFilter contract', async () => {
+      const detail = {
+        ttl: 60_000,
+        limit: 100,
+        key: 'k',
+        tracker: 't',
+        totalHits: 101,
+        timeToExpire: 30,
+        isBlocked: false,
+        timeToBlockExpire: 0,
+      };
+
+      try {
+        // @ts-expect-error — accessing protected method for unit test
+        await guard.throwThrottlingException({} as ExecutionContext, detail);
+        fail('expected throw');
+      } catch (err) {
+        // The thrown exception flows through AllExceptionsFilter, which maps
+        // 4xx HttpException to { status: 'fail', message }. We just assert the
+        // exception carries the right primitives so the filter outputs the
+        // required shape.
+        const httpErr = err as HttpException;
+        expect(httpErr.getStatus()).toBeLessThan(500);
+        expect(httpErr.getStatus()).toBeGreaterThanOrEqual(400);
+        expect(httpErr.message).toBe('Too Many Requests');
+      }
+    });
+  });
+});

--- a/src/common/guards/throttler.guard.ts
+++ b/src/common/guards/throttler.guard.ts
@@ -1,0 +1,11 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+@Injectable()
+export class CustomThrottlerGuard extends ThrottlerGuard {
+  protected override throwThrottlingException(): Promise<void> {
+    return Promise.reject(
+      new HttpException('Too Many Requests', HttpStatus.TOO_MANY_REQUESTS),
+    );
+  }
+}

--- a/src/common/interceptors/correlation-id.interceptor.spec.ts
+++ b/src/common/interceptors/correlation-id.interceptor.spec.ts
@@ -1,0 +1,105 @@
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { lastValueFrom, of } from 'rxjs';
+import {
+  CorrelationIdInterceptor,
+  CORRELATION_ID_HEADER,
+} from './correlation-id.interceptor';
+import { uuidv7, UUID_V7_REGEX } from '../utils/uuid.util';
+
+interface MockResponse {
+  setHeader: jest.Mock;
+  headers: Record<string, string>;
+}
+
+const buildContext = (
+  requestHeaders: Record<string, string | string[] | undefined>,
+  type: 'http' | 'rpc' = 'http',
+): { context: ExecutionContext; response: MockResponse } => {
+  const response: MockResponse = {
+    headers: {},
+    setHeader: jest.fn((key: string, value: string) => {
+      response.headers[key] = value;
+    }),
+  };
+
+  const context = {
+    getType: () => type,
+    switchToHttp: () => ({
+      getRequest: () => ({ headers: requestHeaders }),
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+
+  return { context, response };
+};
+
+const nextHandler: CallHandler = { handle: () => of('ok') };
+
+describe('CorrelationIdInterceptor', () => {
+  let interceptor: CorrelationIdInterceptor;
+
+  beforeEach(() => {
+    interceptor = new CorrelationIdInterceptor();
+  });
+
+  it('generates a UUID v7 when the header is absent', async () => {
+    const { context, response } = buildContext({});
+
+    await lastValueFrom(interceptor.intercept(context, nextHandler));
+
+    expect(response.setHeader).toHaveBeenCalledTimes(1);
+    const value = response.headers[CORRELATION_ID_HEADER];
+    expect(value).toMatch(UUID_V7_REGEX);
+  });
+
+  it('reuses a valid client-provided UUID v7', async () => {
+    const incoming = uuidv7();
+    const { context, response } = buildContext({
+      'x-correlation-id': incoming,
+    });
+
+    await lastValueFrom(interceptor.intercept(context, nextHandler));
+
+    expect(response.headers[CORRELATION_ID_HEADER]).toBe(incoming);
+  });
+
+  it('regenerates when the client header is malformed', async () => {
+    const { context, response } = buildContext({
+      'x-correlation-id': 'not-a-uuid',
+    });
+
+    await lastValueFrom(interceptor.intercept(context, nextHandler));
+
+    expect(response.headers[CORRELATION_ID_HEADER]).toMatch(UUID_V7_REGEX);
+    expect(response.headers[CORRELATION_ID_HEADER]).not.toBe('not-a-uuid');
+  });
+
+  it('regenerates when the client header is a UUID v4 (not v7)', async () => {
+    const v4 = '550e8400-e29b-41d4-a716-446655440000';
+    const { context, response } = buildContext({ 'x-correlation-id': v4 });
+
+    await lastValueFrom(interceptor.intercept(context, nextHandler));
+
+    expect(response.headers[CORRELATION_ID_HEADER]).not.toBe(v4);
+    expect(response.headers[CORRELATION_ID_HEADER]).toMatch(UUID_V7_REGEX);
+  });
+
+  it('handles array-typed headers by using the first element', async () => {
+    const incoming = uuidv7();
+    const { context, response } = buildContext({
+      'x-correlation-id': [incoming, 'second'],
+    });
+
+    await lastValueFrom(interceptor.intercept(context, nextHandler));
+
+    expect(response.headers[CORRELATION_ID_HEADER]).toBe(incoming);
+  });
+
+  it('skips processing for non-http contexts', async () => {
+    const { context, response } = buildContext({}, 'rpc');
+
+    await lastValueFrom(interceptor.intercept(context, nextHandler));
+
+    expect(response.setHeader).not.toHaveBeenCalled();
+  });
+});

--- a/src/common/interceptors/correlation-id.interceptor.ts
+++ b/src/common/interceptors/correlation-id.interceptor.ts
@@ -1,0 +1,32 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { Request, Response } from 'express';
+import { uuidv7, isUuidV7 } from '../utils/uuid.util';
+
+export const CORRELATION_ID_HEADER = 'X-Correlation-ID';
+
+@Injectable()
+export class CorrelationIdInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== 'http') {
+      return next.handle();
+    }
+
+    const ctx = context.switchToHttp();
+    const request = ctx.getRequest<Request>();
+    const response = ctx.getResponse<Response>();
+
+    const incoming = request.headers['x-correlation-id'];
+    const candidate = Array.isArray(incoming) ? incoming[0] : incoming;
+    const correlationId = isUuidV7(candidate) ? candidate : uuidv7();
+
+    response.setHeader(CORRELATION_ID_HEADER, correlationId);
+
+    return next.handle();
+  }
+}

--- a/src/common/utils/uuid.util.spec.ts
+++ b/src/common/utils/uuid.util.spec.ts
@@ -1,0 +1,49 @@
+import { uuidv7, isUuidV7, UUID_V7_REGEX } from './uuid.util';
+
+describe('uuid.util', () => {
+  describe('uuidv7', () => {
+    it('produces a string matching the v7 layout', () => {
+      const id = uuidv7();
+      expect(id).toMatch(UUID_V7_REGEX);
+    });
+
+    it('encodes the current time in the leading 48 bits (monotonic-ish)', () => {
+      const before = Date.now();
+      const id = uuidv7();
+      const after = Date.now();
+
+      const ts = parseInt(id.slice(0, 8) + id.slice(9, 13), 16);
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+
+    it('generates distinct values across rapid invocations', () => {
+      const ids = new Set(Array.from({ length: 1_000 }, () => uuidv7()));
+      expect(ids.size).toBe(1_000);
+    });
+
+    it('sets the version nibble to 7 and the variant to RFC 9562', () => {
+      const id = uuidv7();
+      expect(id.charAt(14)).toBe('7');
+      expect(['8', '9', 'a', 'b']).toContain(id.charAt(19).toLowerCase());
+    });
+  });
+
+  describe('isUuidV7', () => {
+    it('returns true for a freshly generated v7', () => {
+      expect(isUuidV7(uuidv7())).toBe(true);
+    });
+
+    it('returns false for a UUID v4', () => {
+      expect(isUuidV7('550e8400-e29b-41d4-a716-446655440000')).toBe(false);
+    });
+
+    it('returns false for malformed input', () => {
+      expect(isUuidV7('not-a-uuid')).toBe(false);
+      expect(isUuidV7('')).toBe(false);
+      expect(isUuidV7(undefined)).toBe(false);
+      expect(isUuidV7(null)).toBe(false);
+      expect(isUuidV7(12345)).toBe(false);
+    });
+  });
+});

--- a/src/common/utils/uuid.util.ts
+++ b/src/common/utils/uuid.util.ts
@@ -1,0 +1,48 @@
+import { randomBytes } from 'crypto';
+
+/**
+ * Generates an RFC 9562 UUID v7 (time-ordered).
+ *
+ * Layout (128 bits):
+ *   - 48 bits: Unix timestamp in milliseconds (big-endian)
+ *   - 4 bits:  version (0b0111 = 7)
+ *   - 12 bits: random
+ *   - 2 bits:  variant (0b10)
+ *   - 62 bits: random
+ */
+export function uuidv7(): string {
+  const bytes = randomBytes(16);
+  const timestamp = Date.now();
+
+  // 48-bit timestamp
+  bytes[0] = (timestamp / 2 ** 40) & 0xff;
+  bytes[1] = (timestamp / 2 ** 32) & 0xff;
+  bytes[2] = (timestamp >>> 24) & 0xff;
+  bytes[3] = (timestamp >>> 16) & 0xff;
+  bytes[4] = (timestamp >>> 8) & 0xff;
+  bytes[5] = timestamp & 0xff;
+
+  // Version 7 (high nibble of byte 6)
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  // Variant (RFC 4122 / 9562) — top two bits of byte 8 = 10
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = bytes.toString('hex');
+  return (
+    hex.slice(0, 8) +
+    '-' +
+    hex.slice(8, 12) +
+    '-' +
+    hex.slice(12, 16) +
+    '-' +
+    hex.slice(16, 20) +
+    '-' +
+    hex.slice(20, 32)
+  );
+}
+
+export const UUID_V7_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const isUuidV7 = (value: unknown): value is string =>
+  typeof value === 'string' && UUID_V7_REGEX.test(value);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
+import { CorrelationIdInterceptor } from './common/interceptors/correlation-id.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -17,6 +18,7 @@ async function bootstrap() {
   );
 
   app.useGlobalFilters(new AllExceptionsFilter());
+  app.useGlobalInterceptors(new CorrelationIdInterceptor());
 
   await app.listen(process.env.PORT ?? 5000);
 }

--- a/src/modules/health/health.controller.ts
+++ b/src/modules/health/health.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { HealthCheck, HealthCheckService } from '@nestjs/terminus';
 import { ConfigService } from '@nestjs/config';
+import { SkipThrottle } from '@nestjs/throttler';
 import { EnvConfig } from '../../config/env.config';
 import { PrismaHealthIndicator } from './indicators/prisma.health';
 import { TcpHealthIndicator } from './indicators/tcp.health';
@@ -8,6 +9,7 @@ import { SkipTransform } from '../../common/decorators/skip-transform.decorator'
 
 @Controller('health')
 @SkipTransform()
+@SkipThrottle()
 export class HealthController {
   constructor(
     private readonly health: HealthCheckService,

--- a/test/global-middleware.e2e-spec.ts
+++ b/test/global-middleware.e2e-spec.ts
@@ -1,0 +1,114 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  Controller,
+  Get,
+  INestApplication,
+  Module,
+  ValidationPipe,
+} from '@nestjs/common';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { ThrottlerModule, Throttle } from '@nestjs/throttler';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { CorrelationIdInterceptor } from '../src/common/interceptors/correlation-id.interceptor';
+import { CustomThrottlerGuard } from '../src/common/guards/throttler.guard';
+import { AllExceptionsFilter } from '../src/common/filters/all-exceptions.filter';
+import { THROTTLER_LIMITS } from '../src/common/constants/throttler.constants';
+import { UUID_V7_REGEX } from '../src/common/utils/uuid.util';
+
+@Controller('test')
+class TestController {
+  @Get('open')
+  open() {
+    return { ok: true };
+  }
+
+  @Get('strict')
+  @Throttle({
+    default: {
+      limit: THROTTLER_LIMITS.strict.limit,
+      ttl: THROTTLER_LIMITS.strict.ttl,
+    },
+  })
+  strict() {
+    return { ok: true };
+  }
+}
+
+@Module({
+  imports: [
+    ThrottlerModule.forRoot([
+      {
+        limit: THROTTLER_LIMITS.global.limit,
+        ttl: THROTTLER_LIMITS.global.ttl,
+      },
+    ]),
+  ],
+  controllers: [TestController],
+  providers: [
+    { provide: APP_GUARD, useClass: CustomThrottlerGuard },
+    { provide: APP_INTERCEPTOR, useClass: CorrelationIdInterceptor },
+  ],
+})
+class TestAppModule {}
+
+describe('Global middleware (e2e)', () => {
+  let app: INestApplication<App>;
+
+  beforeEach(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [TestAppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),
+    );
+    app.useGlobalFilters(new AllExceptionsFilter());
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('attaches an X-Correlation-ID UUID v7 to every response', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/test/open')
+      .expect(200);
+
+    const header = res.headers['x-correlation-id'];
+    expect(typeof header).toBe('string');
+    expect(header).toMatch(UUID_V7_REGEX);
+  });
+
+  it('reuses a valid client-supplied X-Correlation-ID', async () => {
+    const supplied = '01900000-0000-7000-8000-000000000abc';
+    const res = await request(app.getHttpServer())
+      .get('/test/open')
+      .set('X-Correlation-ID', supplied)
+      .expect(200);
+
+    expect(res.headers['x-correlation-id']).toBe(supplied);
+  });
+
+  it('returns 429 with FailResponse shape after exceeding the strict throttle (5/min)', async () => {
+    const agent = request(app.getHttpServer());
+    for (let i = 0; i < 5; i += 1) {
+      await agent.get('/test/strict').expect(200);
+    }
+
+    const blocked = await agent.get('/test/strict').expect(429);
+    expect(blocked.body).toEqual({
+      status: 'fail',
+      message: 'Too Many Requests',
+    });
+  });
+
+  it('allows more than 5 requests for unmarked routes, using global fallback limit', async () => {
+    const agent = request(app.getHttpServer());
+    for (let i = 0; i < 6; i += 1) {
+      await agent.get('/test/open').expect(200);
+    }
+  });
+});


### PR DESCRIPTION
## 🔗 Closes
Closes #5

---

## 📋 Summary

Implements two global middlewares sesuai SysDesign §11.2:

**1. `CorrelationIdInterceptor`**
Setiap HTTP request diberikan UUID v7 sebagai `X-Correlation-ID`. Jika client sudah mengirim header yang valid (UUID v7), nilainya di-reuse. Jika tidak ada atau invalid, interceptor generate UUID v7 baru. UUID v7 dipilih karena time-ordered — lebih efisien untuk indexing di DB dibanding v4 yang fully random.

**2. Rate Limiting via `@nestjs/throttler`**
Hanya satu unnamed (`default`) throttler yang didaftarkan di `ThrottlerModule.forRoot` (global fallback 100 req/min). Route yang butuh limit lebih ketat override via `@Throttle({ default: { limit, ttl } })` di controller-nya masing-masing. Pendekatan ini menghindari "multi-throttler trap" — kalau semua limit (strict/moderate/global) didaftarkan sekaligus di `forRoot`, semua throttler aktif bersamaan di setiap route dan route biasa akan kena limit 5/min secara diam-diam.

`CustomThrottlerGuard` override `throwThrottlingException` untuk throw `HttpException(429)`, yang kemudian di-handle `AllExceptionsFilter` (dari Issue #1) menghasilkan `{ "status": "fail", "message": "Too Many Requests" }`.

**3. Shared UUID util**
`src/common/utils/uuid.util.ts` — RFC 9562-compliant UUID v7 generator menggunakan `crypto.randomBytes` (no external dep), dapat dipakai ulang di seluruh project (users, companies, dll).

---

## 🔄 Type of Change
- [x] `chore` — Setup, configuration, tooling

---

## ✅ Tasks Completed
- [x] `CorrelationIdInterceptor` — generate UUID v7 per request, inject ke response header `X-Correlation-ID`
- [x] `@nestjs/throttler` setup dengan rate limits sesuai SysDesign §11.2:
  - `POST /users` → 5 req/min *(override via `@Throttle` di UsersController nanti)*
  - `POST /authentications` → 5 req/min *(idem)*
  - `PUT /authentications` → 10 req/min *(idem)*
  - `POST /documents` → 10 req/min *(idem)*
  - Global fallback → 100 req/min ✅ aktif sekarang
- [x] Custom throttler guard yang mengembalikan HTTP `429` dengan `FailResponse` schema `{ status: 'fail', message: '...' }`
- [x] Register `CorrelationIdInterceptor` secara global di `main.ts`
- [x] Register `ThrottlerGuard` secara global di `AppModule`

---

## 🎯 Acceptance Criteria Verified
- [x] Setiap response memiliki header `X-Correlation-ID` berisi UUID v7
- [x] Route dengan `@Throttle({ default: { limit: 5, ttl: 60_000 } })` dikembalikan `429` setelah 5 request dalam 1 menit
- [x] Response `429` mengikuti schema `{ "status": "fail", "message": "Too Many Requests" }`
- [x] Rate limit tidak mempengaruhi endpoint yang tidak di-override (global fallback 100 req/min)

---

## 🧪 How to Test

**Unit tests:**
```bash
npx jest
```

**E2E tests:**
```bash
npx jest --config ./test/jest-e2e.json test/global-middleware.e2e-spec.ts
```

**Manual via curl:**
```bash
# Verify X-Correlation-ID header on every response
curl -i http://localhost:5000/api/v1/health
```

---

## 🔍 Reviewer Checklist
- [x] Code follows naming conventions (SysDesign §6.1)
- [x] No integer `id` is exposed in the response
- [x] No hardcoded credentials
- [x] Soft delete queries filter `deletedAt IS NULL`
- [x] Response shape matches `{ status, data }` / `{ status, message }`
- [x] All new env vars have been added to `.env.example` *(no new env vars introduced)*