### PR TITLE
feat: add JWT auth guard and profile endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { HealthModule } from './modules/health/health.module';
 import { CacheModule } from './modules/cache/cache.module';
 import { UsersModule } from './modules/users/users.module';
 import { AuthenticationsModule } from './modules/authentications/authentications.module';
+import { ProfileModule } from './modules/profile/profile.module';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 import { CustomThrottlerGuard } from './common/guards/throttler.guard';
 import { THROTTLER_LIMITS } from './common/constants/throttler.constants';
@@ -31,6 +32,7 @@ import { THROTTLER_LIMITS } from './common/constants/throttler.constants';
     HealthModule,
     UsersModule,
     AuthenticationsModule,
+    ProfileModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,12 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import type { Request } from 'express';
+import type { JwtPayload } from '../guards/jwt-auth.guard';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): JwtPayload => {
+    const request = ctx
+      .switchToHttp()
+      .getRequest<Request & { user: JwtPayload }>();
+    return request.user;
+  },
+);

--- a/src/common/guards/jwt-auth.guard.spec.ts
+++ b/src/common/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,98 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { JwtAuthGuard, JwtPayload } from './jwt-auth.guard';
+
+const VALID_PAYLOAD: JwtPayload = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+};
+const ACCESS_SECRET = 'test-access-secret';
+
+const buildContext = (authHeader?: string): ExecutionContext => {
+  const request = {
+    headers: authHeader ? { authorization: authHeader } : {},
+    user: undefined as JwtPayload | undefined,
+  };
+
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as unknown as ExecutionContext;
+};
+
+describe('JwtAuthGuard', () => {
+  let guard: JwtAuthGuard;
+  let jwtService: jest.Mocked<JwtService>;
+  let configService: jest.Mocked<ConfigService>;
+
+  beforeEach(() => {
+    jwtService = {
+      verify: jest.fn(),
+    } as unknown as jest.Mocked<JwtService>;
+
+    configService = {
+      get: jest.fn().mockReturnValue(ACCESS_SECRET),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    guard = new JwtAuthGuard(jwtService, configService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('canActivate()', () => {
+    it('should return true and attach user to request when token is valid', () => {
+      jwtService.verify.mockReturnValue(VALID_PAYLOAD);
+      const ctx = buildContext(`Bearer valid.jwt.token`);
+
+      const result = guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(jwtService.verify).toHaveBeenCalledWith('valid.jwt.token', {
+        secret: ACCESS_SECRET,
+      });
+      const req = ctx.switchToHttp().getRequest<{ user: JwtPayload }>();
+      expect(req.user).toEqual(VALID_PAYLOAD);
+    });
+
+    it('should throw UnauthorizedException when Authorization header is missing', () => {
+      const ctx = buildContext();
+
+      expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(ctx)).toThrow('Access token is required');
+      expect(jwtService.verify).not.toHaveBeenCalled();
+    });
+
+    it('should throw UnauthorizedException when header does not start with "Bearer "', () => {
+      const ctx = buildContext('Token abc123');
+
+      expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(ctx)).toThrow('Access token is required');
+    });
+
+    it('should throw UnauthorizedException when token is expired or invalid', () => {
+      jwtService.verify.mockImplementation(() => {
+        throw new Error('jwt expired');
+      });
+      const ctx = buildContext('Bearer expired.jwt.token');
+
+      expect(() => guard.canActivate(ctx)).toThrow(UnauthorizedException);
+      expect(() => guard.canActivate(ctx)).toThrow(
+        'Invalid or expired access token',
+      );
+    });
+
+    it('should use ACCESS_TOKEN_KEY from config to verify', () => {
+      jwtService.verify.mockReturnValue(VALID_PAYLOAD);
+      const ctx = buildContext('Bearer some.token');
+
+      guard.canActivate(ctx);
+
+      expect(configService.get).toHaveBeenCalledWith('ACCESS_TOKEN_KEY');
+      expect(jwtService.verify).toHaveBeenCalledWith(
+        'some.token',
+        expect.objectContaining({ secret: ACCESS_SECRET }),
+      );
+    });
+  });
+});

--- a/src/common/guards/jwt-auth.guard.ts
+++ b/src/common/guards/jwt-auth.guard.ts
@@ -1,0 +1,50 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import type { Request } from 'express';
+import type { EnvConfig } from '../../config/env.config';
+
+export interface JwtPayload {
+  id: string; // user UUID
+  iat?: number;
+  exp?: number;
+}
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly config: ConfigService<EnvConfig, true>,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const token = this.extractBearerToken(request);
+
+    if (!token) {
+      throw new UnauthorizedException('Access token is required');
+    }
+
+    try {
+      const payload = this.jwtService.verify<JwtPayload>(token, {
+        secret: this.config.get('ACCESS_TOKEN_KEY'),
+      });
+      (request as Request & { user: JwtPayload }).user = payload;
+    } catch {
+      throw new UnauthorizedException('Invalid or expired access token');
+    }
+
+    return true;
+  }
+
+  private extractBearerToken(request: Request): string | null {
+    const authHeader = request.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) return null;
+    return authHeader.slice(7);
+  }
+}

--- a/src/modules/profile/dto/pagination-query.dto.ts
+++ b/src/modules/profile/dto/pagination-query.dto.ts
@@ -1,0 +1,29 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 10;
+}
+
+export interface PaginationMeta {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface PaginatedResult<T> {
+  items: T[];
+  meta: PaginationMeta;
+}

--- a/src/modules/profile/dto/profile-application-response.dto.ts
+++ b/src/modules/profile/dto/profile-application-response.dto.ts
@@ -1,0 +1,14 @@
+export class JobSummaryDto {
+  id!: string;
+  title!: string;
+  location!: string;
+  type!: string;
+  salary!: string | null;
+}
+
+export class ProfileApplicationResponseDto {
+  id!: string;
+  status!: string;
+  createdAt!: Date;
+  job!: JobSummaryDto;
+}

--- a/src/modules/profile/dto/profile-bookmark-response.dto.ts
+++ b/src/modules/profile/dto/profile-bookmark-response.dto.ts
@@ -1,0 +1,7 @@
+import { JobSummaryDto } from './profile-application-response.dto';
+
+export class ProfileBookmarkResponseDto {
+  id!: string;
+  createdAt!: Date;
+  job!: JobSummaryDto;
+}

--- a/src/modules/profile/profile.controller.spec.ts
+++ b/src/modules/profile/profile.controller.spec.ts
@@ -1,0 +1,160 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ProfileController } from './profile.controller';
+import { ProfileService } from './profile.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import type { JwtPayload } from '../../common/guards/jwt-auth.guard';
+import type { UserResponseDto } from '../users/dto/user-response.dto';
+import type { PaginatedResult } from './dto/pagination-query.dto';
+import type { ProfileApplicationResponseDto } from './dto/profile-application-response.dto';
+import type { ProfileBookmarkResponseDto } from './dto/profile-bookmark-response.dto';
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const JOB_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const mockUser: JwtPayload = { id: VALID_UUID };
+
+const mockUserResponse: UserResponseDto = {
+  id: VALID_UUID,
+  fullname: 'Jane Doe',
+  email: 'jane@example.com',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+const mockJobSummary = {
+  id: JOB_UUID,
+  title: 'Backend Engineer',
+  location: 'Jakarta',
+  type: 'full-time',
+  salary: null,
+};
+
+const mockApplicationsPage: PaginatedResult<ProfileApplicationResponseDto> = {
+  items: [
+    {
+      id: 'app-uuid-1111',
+      status: 'pending',
+      createdAt: new Date('2026-03-01T00:00:00Z'),
+      job: mockJobSummary,
+    },
+  ],
+  meta: { total: 1, page: 1, limit: 10, totalPages: 1 },
+};
+
+const mockBookmarksPage: PaginatedResult<ProfileBookmarkResponseDto> = {
+  items: [
+    {
+      id: 'bm-uuid-2222',
+      createdAt: new Date('2026-03-02T00:00:00Z'),
+      job: mockJobSummary,
+    },
+  ],
+  meta: { total: 1, page: 1, limit: 10, totalPages: 1 },
+};
+
+describe('ProfileController', () => {
+  let controller: ProfileController;
+  let service: jest.Mocked<ProfileService>;
+
+  beforeEach(async () => {
+    service = {
+      getProfile: jest.fn(),
+      getApplications: jest.fn(),
+      getBookmarks: jest.fn(),
+    } as unknown as jest.Mocked<ProfileService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ProfileController],
+      providers: [{ provide: ProfileService, useValue: service }],
+    })
+      // Bypass JwtAuthGuard — auth behaviour is tested in jwt-auth.guard.spec.ts
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<ProfileController>(ProfileController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -----------------------------------------------------------------------
+  // getProfile()
+  // -----------------------------------------------------------------------
+  describe('getProfile()', () => {
+    it('should call service.getProfile with user UUID and return result', async () => {
+      service.getProfile.mockResolvedValue(mockUserResponse);
+
+      const result = await controller.getProfile(mockUser);
+
+      expect(service.getProfile).toHaveBeenCalledWith(VALID_UUID);
+      expect(result).toEqual(mockUserResponse);
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      service.getProfile.mockRejectedValue(
+        new NotFoundException('User not found'),
+      );
+
+      await expect(controller.getProfile(mockUser)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getApplications()
+  // -----------------------------------------------------------------------
+  describe('getApplications()', () => {
+    it('should call service.getApplications with UUID and query, return paginated result', async () => {
+      service.getApplications.mockResolvedValue(mockApplicationsPage);
+      const query = { page: 1, limit: 10 };
+
+      const result = await controller.getApplications(mockUser, query);
+
+      expect(service.getApplications).toHaveBeenCalledWith(VALID_UUID, query);
+      expect(result.items).toHaveLength(1);
+      expect(result.meta.total).toBe(1);
+    });
+
+    it('should forward page and limit query params to service', async () => {
+      service.getApplications.mockResolvedValue({
+        items: [],
+        meta: { total: 0, page: 2, limit: 5, totalPages: 0 },
+      });
+      const query = { page: 2, limit: 5 };
+
+      await controller.getApplications(mockUser, query);
+
+      expect(service.getApplications).toHaveBeenCalledWith(VALID_UUID, query);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getBookmarks()
+  // -----------------------------------------------------------------------
+  describe('getBookmarks()', () => {
+    it('should call service.getBookmarks with UUID and query, return paginated result', async () => {
+      service.getBookmarks.mockResolvedValue(mockBookmarksPage);
+      const query = { page: 1, limit: 10 };
+
+      const result = await controller.getBookmarks(mockUser, query);
+
+      expect(service.getBookmarks).toHaveBeenCalledWith(VALID_UUID, query);
+      expect(result.items).toHaveLength(1);
+      expect(result.meta.total).toBe(1);
+    });
+
+    it('should forward page and limit query params to service', async () => {
+      service.getBookmarks.mockResolvedValue({
+        items: [],
+        meta: { total: 0, page: 3, limit: 5, totalPages: 0 },
+      });
+      const query = { page: 3, limit: 5 };
+
+      await controller.getBookmarks(mockUser, query);
+
+      expect(service.getBookmarks).toHaveBeenCalledWith(VALID_UUID, query);
+    });
+  });
+});

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ProfileService } from './profile.service';
+import { JwtAuthGuard, JwtPayload } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { UserResponseDto } from '../users/dto/user-response.dto';
+
+@UseGuards(JwtAuthGuard)
+@Controller('profile')
+export class ProfileController {
+  constructor(private readonly profileService: ProfileService) {}
+
+  @Get()
+  getProfile(@CurrentUser() user: JwtPayload): Promise<UserResponseDto> {
+    return this.profileService.getProfile(user.id);
+  }
+}

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -1,10 +1,15 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { ProfileService } from './profile.service';
-import { JwtAuthGuard, JwtPayload } from '../../common/guards/jwt-auth.guard';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import type { JwtPayload } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { UserResponseDto } from '../users/dto/user-response.dto';
-import { PaginatedResult, PaginationQueryDto } from './dto/pagination-query.dto';
+import {
+  PaginatedResult,
+  PaginationQueryDto,
+} from './dto/pagination-query.dto';
 import { ProfileApplicationResponseDto } from './dto/profile-application-response.dto';
+import { ProfileBookmarkResponseDto } from './dto/profile-bookmark-response.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('profile')
@@ -22,5 +27,13 @@ export class ProfileController {
     @Query() query: PaginationQueryDto,
   ): Promise<PaginatedResult<ProfileApplicationResponseDto>> {
     return this.profileService.getApplications(user.id, query);
+  }
+
+  @Get('bookmarks')
+  getBookmarks(
+    @CurrentUser() user: JwtPayload,
+    @Query() query: PaginationQueryDto,
+  ): Promise<PaginatedResult<ProfileBookmarkResponseDto>> {
+    return this.profileService.getBookmarks(user.id, query);
   }
 }

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { ProfileService } from './profile.service';
 import { JwtAuthGuard, JwtPayload } from '../../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { UserResponseDto } from '../users/dto/user-response.dto';
+import { PaginatedResult, PaginationQueryDto } from './dto/pagination-query.dto';
+import { ProfileApplicationResponseDto } from './dto/profile-application-response.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('profile')
@@ -12,5 +14,13 @@ export class ProfileController {
   @Get()
   getProfile(@CurrentUser() user: JwtPayload): Promise<UserResponseDto> {
     return this.profileService.getProfile(user.id);
+  }
+
+  @Get('applications')
+  getApplications(
+    @CurrentUser() user: JwtPayload,
+    @Query() query: PaginationQueryDto,
+  ): Promise<PaginatedResult<ProfileApplicationResponseDto>> {
+    return this.profileService.getApplications(user.id, query);
   }
 }

--- a/src/modules/profile/profile.module.ts
+++ b/src/modules/profile/profile.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { ProfileController } from './profile.controller';
+import { ProfileService } from './profile.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { UsersModule } from '../users/users.module';
+
+@Module({
+  imports: [
+    // JwtModule with no default options; JwtAuthGuard supplies its own
+    // secret per verify call — same pattern as AuthenticationsModule.
+    JwtModule.register({}),
+    UsersModule,
+  ],
+  controllers: [ProfileController],
+  providers: [ProfileService, JwtAuthGuard],
+})
+export class ProfileModule {}

--- a/src/modules/profile/profile.service.spec.ts
+++ b/src/modules/profile/profile.service.spec.ts
@@ -1,0 +1,238 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ProfileService } from './profile.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { UsersService } from '../users/users.service';
+import type { UserResponseDto } from '../users/dto/user-response.dto';
+import type { PaginationQueryDto } from './dto/pagination-query.dto';
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const JOB_UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const mockUserResponse: UserResponseDto = {
+  id: VALID_UUID,
+  fullname: 'Jane Doe',
+  email: 'jane@example.com',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+const mockJob = {
+  uuid: JOB_UUID,
+  title: 'Backend Engineer',
+  location: 'Jakarta',
+  type: 'full-time',
+  salary: null,
+};
+
+const mockApplication = {
+  uuid: 'app-uuid-1111',
+  status: 'pending',
+  createdAt: new Date('2026-03-01T00:00:00Z'),
+  job: mockJob,
+};
+
+const mockBookmark = {
+  uuid: 'bm-uuid-2222',
+  createdAt: new Date('2026-03-02T00:00:00Z'),
+  job: mockJob,
+};
+
+const defaultQuery: PaginationQueryDto = { page: 1, limit: 10 };
+
+describe('ProfileService', () => {
+  let service: ProfileService;
+  let usersService: jest.Mocked<UsersService>;
+  let prisma: {
+    client: {
+      application: {
+        findMany: jest.Mock;
+        count: jest.Mock;
+      };
+      bookmark: {
+        findMany: jest.Mock;
+        count: jest.Mock;
+      };
+    };
+  };
+
+  beforeEach(async () => {
+    usersService = {
+      findByUuid: jest.fn(),
+    } as unknown as jest.Mocked<UsersService>;
+
+    prisma = {
+      client: {
+        application: { findMany: jest.fn(), count: jest.fn() },
+        bookmark: { findMany: jest.fn(), count: jest.fn() },
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProfileService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: UsersService, useValue: usersService },
+      ],
+    }).compile();
+
+    service = module.get<ProfileService>(ProfileService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -----------------------------------------------------------------------
+  // getProfile()
+  // -----------------------------------------------------------------------
+  describe('getProfile()', () => {
+    it('should return the user profile for a given UUID', async () => {
+      usersService.findByUuid.mockResolvedValue({
+        data: mockUserResponse,
+        source: 'database',
+      });
+
+      const result = await service.getProfile(VALID_UUID);
+
+      expect(usersService.findByUuid).toHaveBeenCalledWith(VALID_UUID);
+      expect(result).toEqual(mockUserResponse);
+    });
+
+    it('should propagate NotFoundException from UsersService', async () => {
+      usersService.findByUuid.mockRejectedValue(
+        new NotFoundException('User not found'),
+      );
+
+      await expect(service.getProfile(VALID_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getApplications()
+  // -----------------------------------------------------------------------
+  describe('getApplications()', () => {
+    it('should return paginated applications for the user', async () => {
+      prisma.client.application.findMany.mockResolvedValue([mockApplication]);
+      prisma.client.application.count.mockResolvedValue(1);
+
+      const result = await service.getApplications(VALID_UUID, defaultQuery);
+
+      expect(prisma.client.application.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { user: { uuid: VALID_UUID } },
+          skip: 0,
+          take: 10,
+          orderBy: { createdAt: 'desc' },
+        }),
+      );
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].id).toBe(mockApplication.uuid);
+      expect(result.items[0].status).toBe('pending');
+      expect(result.items[0].job.id).toBe(JOB_UUID);
+    });
+
+    it('should return correct pagination meta', async () => {
+      prisma.client.application.findMany.mockResolvedValue([mockApplication]);
+      prisma.client.application.count.mockResolvedValue(25);
+
+      const result = await service.getApplications(VALID_UUID, {
+        page: 2,
+        limit: 10,
+      });
+
+      expect(result.meta).toEqual({
+        total: 25,
+        page: 2,
+        limit: 10,
+        totalPages: 3,
+      });
+    });
+
+    it('should use correct skip for page > 1', async () => {
+      prisma.client.application.findMany.mockResolvedValue([]);
+      prisma.client.application.count.mockResolvedValue(0);
+
+      await service.getApplications(VALID_UUID, { page: 3, limit: 5 });
+
+      expect(prisma.client.application.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 10, take: 5 }),
+      );
+    });
+
+    it('should return empty items and total=0 when user has no applications', async () => {
+      prisma.client.application.findMany.mockResolvedValue([]);
+      prisma.client.application.count.mockResolvedValue(0);
+
+      const result = await service.getApplications(VALID_UUID, defaultQuery);
+
+      expect(result.items).toHaveLength(0);
+      expect(result.meta.total).toBe(0);
+      expect(result.meta.totalPages).toBe(0);
+    });
+
+    it('should convert Decimal salary to string', async () => {
+      const appWithSalary = {
+        ...mockApplication,
+        job: { ...mockJob, salary: { toString: () => '5000000.00' } },
+      };
+      prisma.client.application.findMany.mockResolvedValue([appWithSalary]);
+      prisma.client.application.count.mockResolvedValue(1);
+
+      const result = await service.getApplications(VALID_UUID, defaultQuery);
+
+      expect(result.items[0].job.salary).toBe('5000000.00');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getBookmarks()
+  // -----------------------------------------------------------------------
+  describe('getBookmarks()', () => {
+    it('should return paginated bookmarks for the user', async () => {
+      prisma.client.bookmark.findMany.mockResolvedValue([mockBookmark]);
+      prisma.client.bookmark.count.mockResolvedValue(1);
+
+      const result = await service.getBookmarks(VALID_UUID, defaultQuery);
+
+      expect(prisma.client.bookmark.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { user: { uuid: VALID_UUID } },
+          skip: 0,
+          take: 10,
+          orderBy: { createdAt: 'desc' },
+        }),
+      );
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].id).toBe(mockBookmark.uuid);
+      expect(result.items[0].job.id).toBe(JOB_UUID);
+    });
+
+    it('should return correct pagination meta', async () => {
+      prisma.client.bookmark.findMany.mockResolvedValue([mockBookmark]);
+      prisma.client.bookmark.count.mockResolvedValue(15);
+
+      const result = await service.getBookmarks(VALID_UUID, {
+        page: 1,
+        limit: 5,
+      });
+
+      expect(result.meta).toEqual({
+        total: 15,
+        page: 1,
+        limit: 5,
+        totalPages: 3,
+      });
+    });
+
+    it('should return empty items when user has no bookmarks', async () => {
+      prisma.client.bookmark.findMany.mockResolvedValue([]);
+      prisma.client.bookmark.count.mockResolvedValue(0);
+
+      const result = await service.getBookmarks(VALID_UUID, defaultQuery);
+
+      expect(result.items).toHaveLength(0);
+      expect(result.meta.totalPages).toBe(0);
+    });
+  });
+});

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -1,13 +1,73 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
 import { UsersService } from '../users/users.service';
 import { UserResponseDto } from '../users/dto/user-response.dto';
+import {
+  PaginatedResult,
+  PaginationQueryDto,
+} from './dto/pagination-query.dto';
+import { ProfileApplicationResponseDto } from './dto/profile-application-response.dto';
 
 @Injectable()
 export class ProfileService {
-  constructor(private readonly usersService: UsersService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly usersService: UsersService,
+  ) {}
 
   async getProfile(uuid: string): Promise<UserResponseDto> {
     const { data } = await this.usersService.findByUuid(uuid);
     return data;
+  }
+
+  async getApplications(
+    uuid: string,
+    query: PaginationQueryDto,
+  ): Promise<PaginatedResult<ProfileApplicationResponseDto>> {
+    const { page, limit } = query;
+    const skip = (page - 1) * limit;
+    const where = { user: { uuid } };
+
+    const [items, total] = await Promise.all([
+      this.prisma.client.application.findMany({
+        where,
+        skip,
+        take: limit,
+        include: {
+          job: {
+            select: {
+              uuid: true,
+              title: true,
+              location: true,
+              type: true,
+              salary: true,
+            },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.client.application.count({ where }),
+    ]);
+
+    return {
+      items: items.map((app) => ({
+        id: app.uuid,
+        status: app.status,
+        createdAt: app.createdAt,
+        job: {
+          id: app.job.uuid,
+          title: app.job.title,
+          location: app.job.location,
+          type: app.job.type,
+          salary: app.job.salary?.toString() ?? null,
+        },
+      })),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
   }
 }

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { UsersService } from '../users/users.service';
+import { UserResponseDto } from '../users/dto/user-response.dto';
+
+@Injectable()
+export class ProfileService {
+  constructor(private readonly usersService: UsersService) {}
+
+  async getProfile(uuid: string): Promise<UserResponseDto> {
+    const { data } = await this.usersService.findByUuid(uuid);
+    return data;
+  }
+}

--- a/src/modules/profile/profile.service.ts
+++ b/src/modules/profile/profile.service.ts
@@ -7,6 +7,7 @@ import {
   PaginationQueryDto,
 } from './dto/pagination-query.dto';
 import { ProfileApplicationResponseDto } from './dto/profile-application-response.dto';
+import { ProfileBookmarkResponseDto } from './dto/profile-bookmark-response.dto';
 
 @Injectable()
 export class ProfileService {
@@ -60,6 +61,56 @@ export class ProfileService {
           location: app.job.location,
           type: app.job.type,
           salary: app.job.salary?.toString() ?? null,
+        },
+      })),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async getBookmarks(
+    uuid: string,
+    query: PaginationQueryDto,
+  ): Promise<PaginatedResult<ProfileBookmarkResponseDto>> {
+    const { page, limit } = query;
+    const skip = (page - 1) * limit;
+    const where = { user: { uuid } };
+
+    const [items, total] = await Promise.all([
+      this.prisma.client.bookmark.findMany({
+        where,
+        skip,
+        take: limit,
+        include: {
+          job: {
+            select: {
+              uuid: true,
+              title: true,
+              location: true,
+              type: true,
+              salary: true,
+            },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+      }),
+      this.prisma.client.bookmark.count({ where }),
+    ]);
+
+    return {
+      items: items.map((bm) => ({
+        id: bm.uuid,
+        createdAt: bm.createdAt,
+        job: {
+          id: bm.job.uuid,
+          title: bm.job.title,
+          location: bm.job.location,
+          type: bm.job.type,
+          salary: bm.job.salary?.toString() ?? null,
         },
       })),
       meta: {

--- a/test/e2e/profile.e2e-spec.ts
+++ b/test/e2e/profile.e2e-spec.ts
@@ -1,0 +1,225 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { ThrottlerStorage } from '@nestjs/throttler';
+import { AppModule } from '../../src/app.module';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { AllExceptionsFilter } from '../../src/common/filters/all-exceptions.filter';
+
+const TEST_USER = {
+  fullname: 'Profile E2E User',
+  email: `profile_e2e_${Date.now()}@example.com`,
+  password: 'StrongPassword123!',
+};
+
+describe('ProfileController (e2e)', () => {
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let accessToken: string;
+  let userId: number;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(ThrottlerStorage)
+      .useValue({
+        increment: jest.fn().mockResolvedValue({
+          totalHits: 0,
+          timeToExpire: 9999,
+          isBlocked: false,
+          timeToBlockExpire: 0,
+        }),
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api/v1');
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }),
+    );
+    app.useGlobalFilters(new AllExceptionsFilter());
+
+    await app.init();
+
+    prisma = app.get(PrismaService);
+
+    // Register test user
+    await request(app.getHttpServer())
+      .post('/api/v1/users')
+      .send(TEST_USER)
+      .expect(201);
+
+    // Login to get access token
+    const loginRes = await request(app.getHttpServer())
+      .post('/api/v1/authentications')
+      .send({ email: TEST_USER.email, password: TEST_USER.password })
+      .expect(201);
+
+    accessToken = (
+      loginRes.body.data as { accessToken: string; refreshToken: string }
+    ).accessToken;
+
+    const userRecord = await prisma.client.user.findUnique({
+      where: { email: TEST_USER.email },
+    });
+    userId = userRecord!.id;
+  });
+
+  afterAll(async () => {
+    await prisma.client.bookmark.deleteMany({ where: { userId } });
+    await prisma.client.application.deleteMany({ where: { userId } });
+    await prisma.client.authentication.deleteMany({});
+    await prisma.client.user.deleteMany({ where: { email: TEST_USER.email } });
+    await app.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth guard — unauthenticated requests
+  // -------------------------------------------------------------------------
+  describe('Auth guard', () => {
+    it('GET /api/v1/profile — 401 when no token', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile')
+        .expect(401);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('GET /api/v1/profile — 401 when token is invalid/garbage', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile')
+        .set('Authorization', 'Bearer this.is.garbage')
+        .expect(401);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('GET /api/v1/profile/applications — 401 when no token', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile/applications')
+        .expect(401);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('GET /api/v1/profile/bookmarks — 401 when no token', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile/bookmarks')
+        .expect(401);
+
+      expect(res.body.status).toBe('fail');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/v1/profile
+  // -------------------------------------------------------------------------
+  describe('GET /api/v1/profile', () => {
+    it('should return the authenticated user profile', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data).toHaveProperty('fullname', TEST_USER.fullname);
+      expect(res.body.data).toHaveProperty('email', TEST_USER.email);
+      expect(res.body.data).toHaveProperty('id');
+      expect(res.body.data.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+      expect(res.body.data).not.toHaveProperty('password');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/v1/profile/applications
+  // -------------------------------------------------------------------------
+  describe('GET /api/v1/profile/applications', () => {
+    it('should return empty paginated list when user has no applications', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile/applications')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.items).toEqual([]);
+      expect(res.body.data.meta).toMatchObject({
+        total: 0,
+        page: 1,
+        limit: 10,
+        totalPages: 0,
+      });
+    });
+
+    it('should return 400 when page is not a positive integer', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile/applications?page=0')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(400);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should return 400 when limit exceeds 100', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile/applications?limit=101')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(400);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should use custom page and limit from query params', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile/applications?page=2&limit=5')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.data.meta.page).toBe(2);
+      expect(res.body.data.meta.limit).toBe(5);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/v1/profile/bookmarks
+  // -------------------------------------------------------------------------
+  describe('GET /api/v1/profile/bookmarks', () => {
+    it('should return empty paginated list when user has no bookmarks', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile/bookmarks')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.items).toEqual([]);
+      expect(res.body.data.meta).toMatchObject({
+        total: 0,
+        page: 1,
+        limit: 10,
+        totalPages: 0,
+      });
+    });
+
+    it('should return 400 when page is not a positive integer', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile/bookmarks?page=0')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(400);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should use custom page and limit from query params', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/profile/bookmarks?page=1&limit=20')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(200);
+
+      expect(res.body.data.meta.page).toBe(1);
+      expect(res.body.data.meta.limit).toBe(20);
+    });
+  });
+});

--- a/test/postman/OpenJob.postman_collection.json
+++ b/test/postman/OpenJob.postman_collection.json
@@ -83,13 +83,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users"]
-            }
+            "url": "{{baseURL}}/users"
           },
           "response": []
         },
@@ -147,13 +141,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users"]
-            }
+            "url": "{{baseURL}}/users"
           },
           "response": []
         },
@@ -181,13 +169,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users", "xxx"]
-            }
+            "url": "{{baseURL}}/users/xxx"
           },
           "response": []
         },
@@ -216,13 +198,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users/{{userId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users", "{{userId}}"]
-            }
+            "url": "{{baseURL}}/users/{{userId}}"
           },
           "response": []
         }
@@ -257,13 +233,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -299,13 +269,7 @@
               "mode": "formdata",
               "formdata": []
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/documents",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "documents"]
-            }
+            "url": "{{baseURL}}/documents"
           },
           "response": []
         },
@@ -343,13 +307,7 @@
               "mode": "formdata",
               "formdata": []
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/documents",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "documents"]
-            }
+            "url": "{{baseURL}}/documents"
           },
           "response": []
         },
@@ -394,13 +352,7 @@
                 }
               ]
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/documents",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "documents"]
-            }
+            "url": "{{baseURL}}/documents"
           },
           "response": []
         },
@@ -454,13 +406,7 @@
                 }
               ]
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/documents",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "documents"]
-            }
+            "url": "{{baseURL}}/documents"
           },
           "response": []
         },
@@ -489,13 +435,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/documents",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "documents"]
-            }
+            "url": "{{baseURL}}/documents"
           },
           "response": []
         },
@@ -522,13 +462,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/documents/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "documents", "xxx"]
-            }
+            "url": "{{baseURL}}/documents/xxx"
           },
           "response": []
         },
@@ -558,13 +492,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/documents/{{documentId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "documents", "{{documentId}}"]
-            }
+            "url": "{{baseURL}}/documents/{{documentId}}"
           },
           "response": []
         },
@@ -586,13 +514,7 @@
           "request": {
             "method": "DELETE",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/documents/{{documentId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "documents", "{{documentId}}"]
-            }
+            "url": "{{baseURL}}/documents/{{documentId}}"
           },
           "response": []
         },
@@ -625,13 +547,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/documents/{{documentId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "documents", "{{documentId}}"]
-            }
+            "url": "{{baseURL}}/documents/{{documentId}}"
           },
           "response": []
         }
@@ -667,13 +583,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -719,13 +629,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies"]
-            }
+            "url": "{{baseURL}}/companies"
           },
           "response": []
         },
@@ -771,13 +675,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "xxx"]
-            }
+            "url": "{{baseURL}}/companies/xxx"
           },
           "response": []
         },
@@ -814,13 +712,7 @@
           "request": {
             "method": "DELETE",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "xxx"]
-            }
+            "url": "{{baseURL}}/companies/xxx"
           },
           "response": []
         },
@@ -893,13 +785,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies"]
-            }
+            "url": "{{baseURL}}/companies"
           },
           "response": []
         },
@@ -944,13 +830,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies"]
-            }
+            "url": "{{baseURL}}/companies"
           },
           "response": []
         },
@@ -979,13 +859,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies"]
-            }
+            "url": "{{baseURL}}/companies"
           },
           "response": []
         },
@@ -1012,13 +886,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "xxx"]
-            }
+            "url": "{{baseURL}}/companies/xxx"
           },
           "response": []
         },
@@ -1048,13 +916,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "{{companyId}}"]
-            }
+            "url": "{{baseURL}}/companies/{{companyId}}"
           },
           "response": []
         },
@@ -1091,13 +953,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "xxx"]
-            }
+            "url": "{{baseURL}}/companies/xxx"
           },
           "response": []
         },
@@ -1140,13 +996,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "{{companyId}}"]
-            }
+            "url": "{{baseURL}}/companies/{{companyId}}"
           },
           "response": []
         },
@@ -1174,13 +1024,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "xxx"]
-            }
+            "url": "{{baseURL}}/companies/xxx"
           },
           "response": []
         },
@@ -1213,13 +1057,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "{{companyId}}"]
-            }
+            "url": "{{baseURL}}/companies/{{companyId}}"
           },
           "response": []
         }
@@ -1270,13 +1108,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories"]
-            }
+            "url": "{{baseURL}}/categories"
           },
           "response": []
         },
@@ -1322,13 +1154,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories", "xxx"]
-            }
+            "url": "{{baseURL}}/categories/xxx"
           },
           "response": []
         },
@@ -1365,13 +1191,7 @@
           "request": {
             "method": "DELETE",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories", "xxx"]
-            }
+            "url": "{{baseURL}}/categories/xxx"
           },
           "response": []
         },
@@ -1444,13 +1264,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories"]
-            }
+            "url": "{{baseURL}}/categories"
           },
           "response": []
         },
@@ -1478,13 +1292,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories", "xxx"]
-            }
+            "url": "{{baseURL}}/categories/xxx"
           },
           "response": []
         },
@@ -1521,13 +1329,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories", "xxx"]
-            }
+            "url": "{{baseURL}}/categories/xxx"
           },
           "response": []
         },
@@ -1555,13 +1357,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories", "xxx"]
-            }
+            "url": "{{baseURL}}/categories/xxx"
           },
           "response": []
         },
@@ -1605,13 +1401,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories"]
-            }
+            "url": "{{baseURL}}/categories"
           },
           "response": []
         },
@@ -1639,13 +1429,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories"]
-            }
+            "url": "{{baseURL}}/categories"
           },
           "response": []
         },
@@ -1673,13 +1457,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories/{{categoryId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories", "{{categoryId}}"]
-            }
+            "url": "{{baseURL}}/categories/{{categoryId}}"
           },
           "response": []
         },
@@ -1716,13 +1494,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories/{{categoryId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories", "{{categoryId}}"]
-            }
+            "url": "{{baseURL}}/categories/{{categoryId}}"
           },
           "response": []
         },
@@ -1750,13 +1522,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories/{{categoryId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories", "{{categoryId}}"]
-            }
+            "url": "{{baseURL}}/categories/{{categoryId}}"
           },
           "response": []
         }
@@ -1797,13 +1563,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies"]
-            }
+            "url": "{{baseURL}}/companies"
           },
           "response": []
         },
@@ -1839,13 +1599,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories"]
-            }
+            "url": "{{baseURL}}/categories"
           },
           "response": []
         },
@@ -1891,13 +1645,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"]
-            }
+            "url": "{{baseURL}}/jobs"
           },
           "response": []
         },
@@ -1943,13 +1691,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "xxx"]
-            }
+            "url": "{{baseURL}}/jobs/xxx"
           },
           "response": []
         },
@@ -1986,13 +1728,7 @@
           "request": {
             "method": "DELETE",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "xxx"]
-            }
+            "url": "{{baseURL}}/jobs/xxx"
           },
           "response": []
         },
@@ -2059,13 +1795,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"]
-            }
+            "url": "{{baseURL}}/jobs"
           },
           "response": []
         },
@@ -2109,13 +1839,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"]
-            }
+            "url": "{{baseURL}}/jobs"
           },
           "response": []
         },
@@ -2144,13 +1868,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"]
-            }
+            "url": "{{baseURL}}/jobs"
           },
           "response": []
         },
@@ -2198,19 +1916,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs?title=Backend",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"],
-              "query": [
-                {
-                  "key": "title",
-                  "value": "Backend"
-                }
-              ]
-            }
+            "url": "{{baseURL}}/jobs?title=Backend"
           },
           "response": []
         },
@@ -2258,19 +1964,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs?company-name=Tech Corp",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"],
-              "query": [
-                {
-                  "key": "company-name",
-                  "value": "Tech Corp"
-                }
-              ]
-            }
+            "url": "{{baseURL}}/jobs?company-name=Tech Corp"
           },
           "response": []
         },
@@ -2320,23 +2014,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs?title=Developer&company-name=Tech",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"],
-              "query": [
-                {
-                  "key": "title",
-                  "value": "Developer"
-                },
-                {
-                  "key": "company-name",
-                  "value": "Tech"
-                }
-              ]
-            }
+            "url": "{{baseURL}}/jobs?title=Developer&company-name=Tech"
           },
           "response": []
         },
@@ -2378,19 +2056,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs?title=NonExistentJobTitle12345",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"],
-              "query": [
-                {
-                  "key": "title",
-                  "value": "NonExistentJobTitle12345"
-                }
-              ]
-            }
+            "url": "{{baseURL}}/jobs?title=NonExistentJobTitle12345"
           },
           "response": []
         },
@@ -2433,23 +2099,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs?title=&company-name=",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"],
-              "query": [
-                {
-                  "key": "title",
-                  "value": ""
-                },
-                {
-                  "key": "company-name",
-                  "value": ""
-                }
-              ]
-            }
+            "url": "{{baseURL}}/jobs?title=&company-name="
           },
           "response": []
         },
@@ -2478,13 +2128,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/company/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "company", "xxx"]
-            }
+            "url": "{{baseURL}}/jobs/company/xxx"
           },
           "response": []
         },
@@ -2519,13 +2163,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/company/{{jobCompanyId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "company", "{{jobCompanyId}}"]
-            }
+            "url": "{{baseURL}}/jobs/company/{{jobCompanyId}}"
           },
           "response": []
         },
@@ -2554,13 +2192,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/category/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "category", "xxx"]
-            }
+            "url": "{{baseURL}}/jobs/category/xxx"
           },
           "response": []
         },
@@ -2595,13 +2227,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/category/{{jobCategoryId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "category", "{{jobCategoryId}}"]
-            }
+            "url": "{{baseURL}}/jobs/category/{{jobCategoryId}}"
           },
           "response": []
         },
@@ -2623,13 +2249,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "xxx"]
-            }
+            "url": "{{baseURL}}/jobs/xxx"
           },
           "response": []
         },
@@ -2659,13 +2279,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "{{jobId}}"]
-            }
+            "url": "{{baseURL}}/jobs/{{jobId}}"
           },
           "response": []
         },
@@ -2702,13 +2316,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "{{jobId}}"]
-            }
+            "url": "{{baseURL}}/jobs/{{jobId}}"
           },
           "response": []
         },
@@ -2736,13 +2344,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "{{jobId}}"]
-            }
+            "url": "{{baseURL}}/jobs/{{jobId}}"
           },
           "response": []
         }
@@ -2783,13 +2385,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"]
-            }
+            "url": "{{baseURL}}/jobs"
           },
           "response": []
         },
@@ -2835,13 +2431,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications"]
-            }
+            "url": "{{baseURL}}/applications"
           },
           "response": []
         },
@@ -2878,13 +2468,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications"]
-            }
+            "url": "{{baseURL}}/applications"
           },
           "response": []
         },
@@ -2921,13 +2505,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "xxx"]
-            }
+            "url": "{{baseURL}}/applications/xxx"
           },
           "response": []
         },
@@ -2971,13 +2549,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications"]
-            }
+            "url": "{{baseURL}}/applications"
           },
           "response": []
         },
@@ -3011,13 +2583,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications"]
-            }
+            "url": "{{baseURL}}/applications"
           },
           "response": []
         },
@@ -3052,13 +2618,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/{{applicationId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "{{applicationId}}"]
-            }
+            "url": "{{baseURL}}/applications/{{applicationId}}"
           },
           "response": []
         },
@@ -3093,13 +2653,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/user/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "user", "xxx"]
-            }
+            "url": "{{baseURL}}/applications/user/xxx"
           },
           "response": []
         },
@@ -3140,13 +2694,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/user/{{userId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "user", "{{userId}}"]
-            }
+            "url": "{{baseURL}}/applications/user/{{userId}}"
           },
           "response": []
         },
@@ -3181,13 +2729,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/job/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "job", "xxx"]
-            }
+            "url": "{{baseURL}}/applications/job/xxx"
           },
           "response": []
         },
@@ -3228,19 +2770,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/job/{{applicationJobId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "job",
-                "{{applicationJobId}}"
-              ]
-            }
+            "url": "{{baseURL}}/applications/job/{{applicationJobId}}"
           },
           "response": []
         },
@@ -3268,13 +2798,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/user/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "user", "xxx"]
-            }
+            "url": "{{baseURL}}/applications/user/xxx"
           },
           "response": []
         },
@@ -3302,13 +2826,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/job/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "job", "xxx"]
-            }
+            "url": "{{baseURL}}/applications/job/xxx"
           },
           "response": []
         },
@@ -3345,13 +2863,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/{{applicationId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "{{applicationId}}"]
-            }
+            "url": "{{baseURL}}/applications/{{applicationId}}"
           },
           "response": []
         },
@@ -3379,13 +2891,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/{{applicationId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "{{applicationId}}"]
-            }
+            "url": "{{baseURL}}/applications/{{applicationId}}"
           },
           "response": []
         }
@@ -3426,13 +2932,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"]
-            }
+            "url": "{{baseURL}}/jobs"
           },
           "response": []
         },
@@ -3478,13 +2978,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark"]
-            }
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark"
           },
           "response": []
         },
@@ -3521,13 +3015,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/bookmarks",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "bookmarks"]
-            }
+            "url": "{{baseURL}}/bookmarks"
           },
           "response": []
         },
@@ -3564,13 +3052,7 @@
           "request": {
             "method": "DELETE",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark"]
-            }
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark"
           },
           "response": []
         },
@@ -3614,13 +3096,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark"]
-            }
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark"
           },
           "response": []
         },
@@ -3655,13 +3131,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/bookmarks",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "bookmarks"]
-            }
+            "url": "{{baseURL}}/bookmarks"
           },
           "response": []
         },
@@ -3695,13 +3165,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark/xxx",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark", "xxx"]
-            }
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark/xxx"
           },
           "response": []
         },
@@ -3736,20 +3200,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark/{{bookmarkId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{jobId}}",
-                "bookmark",
-                "{{bookmarkId}}"
-              ]
-            }
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark/{{bookmarkId}}"
           },
           "response": []
         },
@@ -3777,13 +3228,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark"]
-            }
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark"
           },
           "response": []
         }
@@ -3806,13 +3251,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users"]
-            }
+            "url": "{{baseURL}}/users"
           },
           "response": []
         },
@@ -3830,13 +3269,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users"]
-            }
+            "url": "{{baseURL}}/users"
           },
           "response": []
         },
@@ -3915,13 +3348,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -3931,7 +3358,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -3975,13 +3404,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -3991,7 +3414,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -4035,13 +3460,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4051,7 +3470,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -4100,13 +3521,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4116,7 +3531,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -4165,13 +3582,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4218,13 +3629,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4271,13 +3676,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4324,13 +3723,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4378,13 +3771,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4437,13 +3824,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4496,13 +3877,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4555,13 +3930,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4614,13 +3983,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4667,13 +4030,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         }
@@ -4709,13 +4066,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -4752,13 +4103,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/profile",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "profile"]
-            }
+            "url": "{{baseURL}}/profile"
           },
           "response": []
         },
@@ -4801,13 +4146,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/profile",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "profile"]
-            }
+            "url": "{{baseURL}}/profile"
           },
           "response": []
         },
@@ -4853,13 +4192,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/profile",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "profile"]
-            }
+            "url": "{{baseURL}}/profile"
           },
           "response": []
         },
@@ -4896,13 +4229,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/profile/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "profile", "applications"]
-            }
+            "url": "{{baseURL}}/profile/applications"
           },
           "response": []
         },
@@ -4950,13 +4277,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/profile/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "profile", "applications"]
-            }
+            "url": "{{baseURL}}/profile/applications"
           },
           "response": []
         },
@@ -4993,13 +4314,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/profile/bookmarks",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "profile", "bookmarks"]
-            }
+            "url": "{{baseURL}}/profile/bookmarks"
           },
           "response": []
         },
@@ -5047,13 +4362,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/profile/bookmarks",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "profile", "bookmarks"]
-            }
+            "url": "{{baseURL}}/profile/bookmarks"
           },
           "response": []
         },
@@ -5090,13 +4399,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         }
@@ -5137,13 +4440,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies"]
-            }
+            "url": "{{baseURL}}/companies"
           },
           "response": []
         },
@@ -5173,13 +4470,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users"]
-            }
+            "url": "{{baseURL}}/users"
           },
           "response": []
         },
@@ -5215,13 +4506,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"]
-            }
+            "url": "{{baseURL}}/jobs"
           },
           "response": []
         },
@@ -5257,13 +4542,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications"]
-            }
+            "url": "{{baseURL}}/applications"
           },
           "response": []
         },
@@ -5273,7 +4552,9 @@
             {
               "listen": "test",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             }
@@ -5296,13 +4577,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark"]
-            }
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark"
           },
           "response": []
         },
@@ -5333,13 +4608,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "{{companyId}}"]
-            }
+            "url": "{{baseURL}}/companies/{{companyId}}"
           },
           "response": []
         },
@@ -5370,13 +4639,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "{{companyId}}"]
-            }
+            "url": "{{baseURL}}/companies/{{companyId}}"
           },
           "response": []
         },
@@ -5407,13 +4670,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users/{{newUserId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users", "{{newUserId}}"]
-            }
+            "url": "{{baseURL}}/users/{{newUserId}}"
           },
           "response": []
         },
@@ -5444,13 +4701,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users/{{newUserId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users", "{{newUserId}}"]
-            }
+            "url": "{{baseURL}}/users/{{newUserId}}"
           },
           "response": []
         },
@@ -5482,13 +4733,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/{{applicationId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "{{applicationId}}"]
-            }
+            "url": "{{baseURL}}/applications/{{applicationId}}"
           },
           "response": []
         },
@@ -5520,13 +4765,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/{{applicationId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "{{applicationId}}"]
-            }
+            "url": "{{baseURL}}/applications/{{applicationId}}"
           },
           "response": []
         },
@@ -5558,13 +4797,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/user/{{userId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "user", "{{userId}}"]
-            }
+            "url": "{{baseURL}}/applications/user/{{userId}}"
           },
           "response": []
         },
@@ -5596,13 +4829,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/user/{{userId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "user", "{{userId}}"]
-            }
+            "url": "{{baseURL}}/applications/user/{{userId}}"
           },
           "response": []
         },
@@ -5634,19 +4861,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/job/{{applicationJobId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "job",
-                "{{applicationJobId}}"
-              ]
-            }
+            "url": "{{baseURL}}/applications/job/{{applicationJobId}}"
           },
           "response": []
         },
@@ -5678,19 +4893,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/job/{{applicationJobId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "job",
-                "{{applicationJobId}}"
-              ]
-            }
+            "url": "{{baseURL}}/applications/job/{{applicationJobId}}"
           },
           "response": []
         },
@@ -5722,13 +4925,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/bookmarks",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "bookmarks"]
-            }
+            "url": "{{baseURL}}/bookmarks"
           },
           "response": []
         },
@@ -5760,13 +4957,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/bookmarks",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "bookmarks"]
-            }
+            "url": "{{baseURL}}/bookmarks"
           },
           "response": []
         },
@@ -5808,13 +4999,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "{{companyId}}"]
-            }
+            "url": "{{baseURL}}/companies/{{companyId}}"
           },
           "response": []
         },
@@ -5845,13 +5030,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "{{companyId}}"]
-            }
+            "url": "{{baseURL}}/companies/{{companyId}}"
           },
           "response": []
         },
@@ -5887,13 +5066,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"]
-            }
+            "url": "{{baseURL}}/jobs"
           },
           "response": []
         },
@@ -5935,13 +5108,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications"]
-            }
+            "url": "{{baseURL}}/applications"
           },
           "response": []
         },
@@ -5980,13 +5147,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/user/{{userId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "user", "{{userId}}"]
-            }
+            "url": "{{baseURL}}/applications/user/{{userId}}"
           },
           "response": []
         },
@@ -6023,13 +5184,7 @@
                 }
               }
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/{{newApplicationId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "{{newApplicationId}}"]
-            }
+            "url": "{{baseURL}}/applications/{{newApplicationId}}"
           },
           "response": []
         },
@@ -6066,13 +5221,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/{{newApplicationId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "{{newApplicationId}}"]
-            }
+            "url": "{{baseURL}}/applications/{{newApplicationId}}"
           },
           "response": []
         }
@@ -6112,13 +5261,7 @@
               "mode": "raw",
               "raw": "{\n  \"name\": \"Job Owner\",\n  \"email\": \"gilangheavy@gmail.com\",\n  \"password\": \"password123\",\n  \"role\": \"user\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users"]
-            }
+            "url": "{{baseURL}}/users"
           },
           "response": []
         },
@@ -6153,13 +5296,7 @@
               "mode": "raw",
               "raw": "{\n  \"name\": \"Job Applicant\",\n  \"email\": \"applicant@example.com\",\n  \"password\": \"password123\",\n  \"role\": \"user\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/users",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "users"]
-            }
+            "url": "{{baseURL}}/users"
           },
           "response": []
         },
@@ -6193,13 +5330,7 @@
               "mode": "raw",
               "raw": "{\n  \"email\": \"gilangheavy@gmail.com\",\n  \"password\": \"password123\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -6232,13 +5363,7 @@
               "mode": "raw",
               "raw": "{\n  \"email\": \"applicant@example.com\",\n  \"password\": \"password123\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/authentications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "authentications"]
-            }
+            "url": "{{baseURL}}/authentications"
           },
           "response": []
         },
@@ -6268,13 +5393,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/profile",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "profile"]
-            }
+            "url": "{{baseURL}}/profile"
           },
           "response": []
         },
@@ -6304,13 +5423,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/profile",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "profile"]
-            }
+            "url": "{{baseURL}}/profile"
           },
           "response": []
         },
@@ -6351,13 +5464,7 @@
               "mode": "raw",
               "raw": "{\n  \"name\": \"MQ Test Company {{$timestamp}}\",\n  \"location\": \"Jakarta\",\n  \"description\": \"Company for RabbitMQ test\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies"]
-            }
+            "url": "{{baseURL}}/companies"
           },
           "response": []
         },
@@ -6395,13 +5502,7 @@
               "mode": "raw",
               "raw": "{\n  \"name\": \"MQ Test Category {{$timestamp}}\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories"]
-            }
+            "url": "{{baseURL}}/categories"
           },
           "response": []
         },
@@ -6442,13 +5543,7 @@
               "mode": "raw",
               "raw": "{\n  \"company_id\": \"{{mqCompanyId}}\",\n  \"category_id\": \"{{mqCategoryId}}\",\n  \"title\": \"RabbitMQ Test Job\",\n  \"description\": \"Testing RabbitMQ notification on application\",\n  \"job_type\": \"full-time\",\n  \"experience_level\": \"mid\",\n  \"location_type\": \"remote\",\n  \"location_city\": \"Jakarta\",\n  \"salary_min\": 5000000,\n  \"salary_max\": 10000000,\n  \"is_salary_visible\": true,\n  \"status\": \"open\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs"]
-            }
+            "url": "{{baseURL}}/jobs"
           },
           "response": []
         },
@@ -6508,13 +5603,7 @@
               "mode": "raw",
               "raw": "{\n  \"user_id\": \"{{applicantUserId}}\",\n  \"job_id\": \"{{mqJobId}}\",\n  \"status\": \"pending\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications"]
-            }
+            "url": "{{baseURL}}/applications"
           },
           "response": []
         },
@@ -6556,13 +5645,7 @@
               "mode": "raw",
               "raw": "{\n  \"user_id\": \"{{applicantUserId}}\",\n  \"job_id\": \"{{mqJobId}}\",\n  \"status\": \"pending\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications"]
-            }
+            "url": "{{baseURL}}/applications"
           },
           "response": []
         },
@@ -6599,13 +5682,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/{{mqApplicationId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "{{mqApplicationId}}"]
-            }
+            "url": "{{baseURL}}/applications/{{mqApplicationId}}"
           },
           "response": []
         },
@@ -6641,13 +5718,7 @@
               "mode": "raw",
               "raw": "{\n  \"user_id\": \"{{applicantUserId}}\",\n  \"job_id\": \"{{mqJobId}}\",\n  \"status\": \"pending\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications"]
-            }
+            "url": "{{baseURL}}/applications"
           },
           "response": []
         },
@@ -6688,13 +5759,7 @@
               "mode": "raw",
               "raw": "{\n  \"user_id\": \"{{applicantUserId}}\",\n  \"job_id\": \"job-nonexistent-id-xxx\",\n  \"status\": \"pending\"\n}"
             },
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications"]
-            }
+            "url": "{{baseURL}}/applications"
           },
           "response": []
         },
@@ -6722,13 +5787,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/applications/{{mqApplicationId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "applications", "{{mqApplicationId}}"]
-            }
+            "url": "{{baseURL}}/applications/{{mqApplicationId}}"
           },
           "response": []
         },
@@ -6756,13 +5815,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/jobs/{{mqJobId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "jobs", "{{mqJobId}}"]
-            }
+            "url": "{{baseURL}}/jobs/{{mqJobId}}"
           },
           "response": []
         },
@@ -6790,13 +5843,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/companies/{{mqCompanyId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "companies", "{{mqCompanyId}}"]
-            }
+            "url": "{{baseURL}}/companies/{{mqCompanyId}}"
           },
           "response": []
         },
@@ -6824,13 +5871,7 @@
                 "type": "text"
               }
             ],
-            "url": {
-              "raw": "http://localhost:{{port}}/api/v1/categories/{{mqCategoryId}}",
-              "protocol": "http",
-              "host": ["localhost"],
-              "port": "{{port}}",
-              "path": ["api", "v1", "categories", "{{mqCategoryId}}"]
-            }
+            "url": "{{baseURL}}/categories/{{mqCategoryId}}"
           },
           "response": []
         }

--- a/test/postman/OpenJob.postman_collection.json
+++ b/test/postman/OpenJob.postman_collection.json
@@ -7,7 +7,7 @@
   },
   "item": [
     {
-      "name": "[Mandatory] Users",
+      "name": "Users",
       "item": [
         {
           "name": "Add User with Invalid Payload",
@@ -86,15 +86,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users"
-              ]
+              "path": ["api", "v1", "users"]
             }
           },
           "response": []
@@ -156,15 +150,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users"
-              ]
+              "path": ["api", "v1", "users"]
             }
           },
           "response": []
@@ -196,16 +184,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users",
-                "xxx"
-              ]
+              "path": ["api", "v1", "users", "xxx"]
             }
           },
           "response": []
@@ -238,16 +219,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users/{{userId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users",
-                "{{userId}}"
-              ]
+              "path": ["api", "v1", "users", "{{userId}}"]
             }
           },
           "response": []
@@ -255,7 +229,7 @@
       ]
     },
     {
-      "name": "[Mandatory] Documents",
+      "name": "Documents",
       "item": [
         {
           "name": "[Setup] - Login for Documents Test",
@@ -286,15 +260,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -334,15 +302,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/documents",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "documents"
-              ]
+              "path": ["api", "v1", "documents"]
             }
           },
           "response": []
@@ -384,15 +346,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/documents",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "documents"
-              ]
+              "path": ["api", "v1", "documents"]
             }
           },
           "response": []
@@ -441,15 +397,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/documents",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "documents"
-              ]
+              "path": ["api", "v1", "documents"]
             }
           },
           "response": []
@@ -507,15 +457,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/documents",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "documents"
-              ]
+              "path": ["api", "v1", "documents"]
             }
           },
           "response": []
@@ -548,15 +492,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/documents",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "documents"
-              ]
+              "path": ["api", "v1", "documents"]
             }
           },
           "response": []
@@ -587,16 +525,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/documents/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "documents",
-                "xxx"
-              ]
+              "path": ["api", "v1", "documents", "xxx"]
             }
           },
           "response": []
@@ -630,16 +561,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/documents/{{documentId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "documents",
-                "{{documentId}}"
-              ]
+              "path": ["api", "v1", "documents", "{{documentId}}"]
             }
           },
           "response": []
@@ -665,16 +589,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/documents/{{documentId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "documents",
-                "{{documentId}}"
-              ]
+              "path": ["api", "v1", "documents", "{{documentId}}"]
             }
           },
           "response": []
@@ -711,16 +628,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/documents/{{documentId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "documents",
-                "{{documentId}}"
-              ]
+              "path": ["api", "v1", "documents", "{{documentId}}"]
             }
           },
           "response": []
@@ -760,15 +670,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -818,15 +722,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies"
-              ]
+              "path": ["api", "v1", "companies"]
             }
           },
           "response": []
@@ -876,16 +774,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "xxx"
-              ]
+              "path": ["api", "v1", "companies", "xxx"]
             }
           },
           "response": []
@@ -926,16 +817,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "xxx"
-              ]
+              "path": ["api", "v1", "companies", "xxx"]
             }
           },
           "response": []
@@ -1012,15 +896,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies"
-              ]
+              "path": ["api", "v1", "companies"]
             }
           },
           "response": []
@@ -1069,15 +947,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies"
-              ]
+              "path": ["api", "v1", "companies"]
             }
           },
           "response": []
@@ -1110,15 +982,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies"
-              ]
+              "path": ["api", "v1", "companies"]
             }
           },
           "response": []
@@ -1149,16 +1015,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "xxx"
-              ]
+              "path": ["api", "v1", "companies", "xxx"]
             }
           },
           "response": []
@@ -1192,16 +1051,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "{{companyId}}"
-              ]
+              "path": ["api", "v1", "companies", "{{companyId}}"]
             }
           },
           "response": []
@@ -1242,16 +1094,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "xxx"
-              ]
+              "path": ["api", "v1", "companies", "xxx"]
             }
           },
           "response": []
@@ -1298,16 +1143,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "{{companyId}}"
-              ]
+              "path": ["api", "v1", "companies", "{{companyId}}"]
             }
           },
           "response": []
@@ -1339,16 +1177,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "xxx"
-              ]
+              "path": ["api", "v1", "companies", "xxx"]
             }
           },
           "response": []
@@ -1385,16 +1216,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "{{companyId}}"
-              ]
+              "path": ["api", "v1", "companies", "{{companyId}}"]
             }
           },
           "response": []
@@ -1449,15 +1273,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories"
-              ]
+              "path": ["api", "v1", "categories"]
             }
           },
           "response": []
@@ -1507,16 +1325,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories",
-                "xxx"
-              ]
+              "path": ["api", "v1", "categories", "xxx"]
             }
           },
           "response": []
@@ -1557,16 +1368,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories",
-                "xxx"
-              ]
+              "path": ["api", "v1", "categories", "xxx"]
             }
           },
           "response": []
@@ -1643,15 +1447,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories"
-              ]
+              "path": ["api", "v1", "categories"]
             }
           },
           "response": []
@@ -1683,16 +1481,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories",
-                "xxx"
-              ]
+              "path": ["api", "v1", "categories", "xxx"]
             }
           },
           "response": []
@@ -1733,16 +1524,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories",
-                "xxx"
-              ]
+              "path": ["api", "v1", "categories", "xxx"]
             }
           },
           "response": []
@@ -1774,16 +1558,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories",
-                "xxx"
-              ]
+              "path": ["api", "v1", "categories", "xxx"]
             }
           },
           "response": []
@@ -1831,15 +1608,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories"
-              ]
+              "path": ["api", "v1", "categories"]
             }
           },
           "response": []
@@ -1871,15 +1642,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories"
-              ]
+              "path": ["api", "v1", "categories"]
             }
           },
           "response": []
@@ -1911,16 +1676,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories/{{categoryId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories",
-                "{{categoryId}}"
-              ]
+              "path": ["api", "v1", "categories", "{{categoryId}}"]
             }
           },
           "response": []
@@ -1961,16 +1719,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories/{{categoryId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories",
-                "{{categoryId}}"
-              ]
+              "path": ["api", "v1", "categories", "{{categoryId}}"]
             }
           },
           "response": []
@@ -2002,16 +1753,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories/{{categoryId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories",
-                "{{categoryId}}"
-              ]
+              "path": ["api", "v1", "categories", "{{categoryId}}"]
             }
           },
           "response": []
@@ -2056,15 +1800,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies"
-              ]
+              "path": ["api", "v1", "companies"]
             }
           },
           "response": []
@@ -2104,15 +1842,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories"
-              ]
+              "path": ["api", "v1", "categories"]
             }
           },
           "response": []
@@ -2162,15 +1894,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ]
+              "path": ["api", "v1", "jobs"]
             }
           },
           "response": []
@@ -2220,16 +1946,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "xxx"
-              ]
+              "path": ["api", "v1", "jobs", "xxx"]
             }
           },
           "response": []
@@ -2270,16 +1989,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "xxx"
-              ]
+              "path": ["api", "v1", "jobs", "xxx"]
             }
           },
           "response": []
@@ -2350,15 +2062,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ]
+              "path": ["api", "v1", "jobs"]
             }
           },
           "response": []
@@ -2406,15 +2112,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ]
+              "path": ["api", "v1", "jobs"]
             }
           },
           "response": []
@@ -2447,15 +2147,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ]
+              "path": ["api", "v1", "jobs"]
             }
           },
           "response": []
@@ -2507,15 +2201,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs?title=Backend",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ],
+              "path": ["api", "v1", "jobs"],
               "query": [
                 {
                   "key": "title",
@@ -2573,15 +2261,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs?company-name=Tech Corp",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ],
+              "path": ["api", "v1", "jobs"],
               "query": [
                 {
                   "key": "company-name",
@@ -2641,15 +2323,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs?title=Developer&company-name=Tech",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ],
+              "path": ["api", "v1", "jobs"],
               "query": [
                 {
                   "key": "title",
@@ -2705,15 +2381,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs?title=NonExistentJobTitle12345",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ],
+              "path": ["api", "v1", "jobs"],
               "query": [
                 {
                   "key": "title",
@@ -2766,15 +2436,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs?title=&company-name=",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ],
+              "path": ["api", "v1", "jobs"],
               "query": [
                 {
                   "key": "title",
@@ -2817,17 +2481,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/company/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "company",
-                "xxx"
-              ]
+              "path": ["api", "v1", "jobs", "company", "xxx"]
             }
           },
           "response": []
@@ -2866,17 +2522,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/company/{{jobCompanyId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "company",
-                "{{jobCompanyId}}"
-              ]
+              "path": ["api", "v1", "jobs", "company", "{{jobCompanyId}}"]
             }
           },
           "response": []
@@ -2909,17 +2557,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/category/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "category",
-                "xxx"
-              ]
+              "path": ["api", "v1", "jobs", "category", "xxx"]
             }
           },
           "response": []
@@ -2958,17 +2598,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/category/{{jobCategoryId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "category",
-                "{{jobCategoryId}}"
-              ]
+              "path": ["api", "v1", "jobs", "category", "{{jobCategoryId}}"]
             }
           },
           "response": []
@@ -2994,16 +2626,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "xxx"
-              ]
+              "path": ["api", "v1", "jobs", "xxx"]
             }
           },
           "response": []
@@ -3037,16 +2662,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{jobId}}"
-              ]
+              "path": ["api", "v1", "jobs", "{{jobId}}"]
             }
           },
           "response": []
@@ -3087,16 +2705,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{jobId}}"
-              ]
+              "path": ["api", "v1", "jobs", "{{jobId}}"]
             }
           },
           "response": []
@@ -3128,16 +2739,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{jobId}}"
-              ]
+              "path": ["api", "v1", "jobs", "{{jobId}}"]
             }
           },
           "response": []
@@ -3182,15 +2786,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ]
+              "path": ["api", "v1", "jobs"]
             }
           },
           "response": []
@@ -3240,15 +2838,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications"
-              ]
+              "path": ["api", "v1", "applications"]
             }
           },
           "response": []
@@ -3289,15 +2881,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications"
-              ]
+              "path": ["api", "v1", "applications"]
             }
           },
           "response": []
@@ -3338,16 +2924,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "xxx"
-              ]
+              "path": ["api", "v1", "applications", "xxx"]
             }
           },
           "response": []
@@ -3395,15 +2974,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications"
-              ]
+              "path": ["api", "v1", "applications"]
             }
           },
           "response": []
@@ -3441,15 +3014,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications"
-              ]
+              "path": ["api", "v1", "applications"]
             }
           },
           "response": []
@@ -3488,16 +3055,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/{{applicationId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "{{applicationId}}"
-              ]
+              "path": ["api", "v1", "applications", "{{applicationId}}"]
             }
           },
           "response": []
@@ -3536,17 +3096,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/user/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "user",
-                "xxx"
-              ]
+              "path": ["api", "v1", "applications", "user", "xxx"]
             }
           },
           "response": []
@@ -3591,17 +3143,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/user/{{userId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "user",
-                "{{userId}}"
-              ]
+              "path": ["api", "v1", "applications", "user", "{{userId}}"]
             }
           },
           "response": []
@@ -3640,17 +3184,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/job/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "job",
-                "xxx"
-              ]
+              "path": ["api", "v1", "applications", "job", "xxx"]
             }
           },
           "response": []
@@ -3695,9 +3231,7 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/job/{{applicationJobId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
               "path": [
                 "api",
@@ -3737,17 +3271,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/user/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "user",
-                "xxx"
-              ]
+              "path": ["api", "v1", "applications", "user", "xxx"]
             }
           },
           "response": []
@@ -3779,17 +3305,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/job/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "job",
-                "xxx"
-              ]
+              "path": ["api", "v1", "applications", "job", "xxx"]
             }
           },
           "response": []
@@ -3830,16 +3348,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/{{applicationId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "{{applicationId}}"
-              ]
+              "path": ["api", "v1", "applications", "{{applicationId}}"]
             }
           },
           "response": []
@@ -3871,16 +3382,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/{{applicationId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "{{applicationId}}"
-              ]
+              "path": ["api", "v1", "applications", "{{applicationId}}"]
             }
           },
           "response": []
@@ -3925,15 +3429,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ]
+              "path": ["api", "v1", "jobs"]
             }
           },
           "response": []
@@ -3983,17 +3481,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{jobId}}",
-                "bookmark"
-              ]
+              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark"]
             }
           },
           "response": []
@@ -4034,15 +3524,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/bookmarks",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "bookmarks"
-              ]
+              "path": ["api", "v1", "bookmarks"]
             }
           },
           "response": []
@@ -4083,17 +3567,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{jobId}}",
-                "bookmark"
-              ]
+              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark"]
             }
           },
           "response": []
@@ -4141,17 +3617,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{jobId}}",
-                "bookmark"
-              ]
+              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark"]
             }
           },
           "response": []
@@ -4190,15 +3658,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/bookmarks",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "bookmarks"
-              ]
+              "path": ["api", "v1", "bookmarks"]
             }
           },
           "response": []
@@ -4236,18 +3698,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark/xxx",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{jobId}}",
-                "bookmark",
-                "xxx"
-              ]
+              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark", "xxx"]
             }
           },
           "response": []
@@ -4286,9 +3739,7 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark/{{bookmarkId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
               "path": [
                 "api",
@@ -4329,17 +3780,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{jobId}}",
-                "bookmark"
-              ]
+              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark"]
             }
           },
           "response": []
@@ -4366,15 +3809,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users"
-              ]
+              "path": ["api", "v1", "users"]
             }
           },
           "response": []
@@ -4396,15 +3833,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users"
-              ]
+              "path": ["api", "v1", "users"]
             }
           },
           "response": []
@@ -4487,15 +3918,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -4506,9 +3931,7 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript"
               }
             },
@@ -4555,15 +3978,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -4574,9 +3991,7 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript"
               }
             },
@@ -4623,15 +4038,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -4642,9 +4051,7 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript"
               }
             },
@@ -4696,15 +4103,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -4715,9 +4116,7 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript"
               }
             },
@@ -4769,15 +4168,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -4828,15 +4221,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -4887,15 +4274,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -4946,15 +4327,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -5006,15 +4381,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -5071,15 +4440,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -5136,15 +4499,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -5201,15 +4558,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -5266,15 +4617,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -5325,15 +4670,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -5341,7 +4680,7 @@
       ]
     },
     {
-      "name": "[Opsional] Profile",
+      "name": "Profile",
       "item": [
         {
           "name": "[Setup] - Login User for Profile",
@@ -5373,15 +4712,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -5408,7 +4741,7 @@
                   "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('failed');",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
                   "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
@@ -5422,15 +4755,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/profile",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "profile"
-              ]
+              "path": ["api", "v1", "profile"]
             }
           },
           "response": []
@@ -5457,7 +4784,7 @@
                   "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('failed');",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
                   "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
@@ -5477,15 +4804,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/profile",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "profile"
-              ]
+              "path": ["api", "v1", "profile"]
             }
           },
           "response": []
@@ -5515,9 +4836,8 @@
                   "    pm.expect(responseJson.status).to.equal('success');",
                   "    pm.expect(responseJson.data).to.be.an('object');",
                   "    pm.expect(responseJson.data.id).to.be.a('string');",
-                  "    pm.expect(responseJson.data.name).to.equal('John Doe');",
+                  "    pm.expect(responseJson.data.fullname).to.equal('John Doe');",
                   "    pm.expect(responseJson.data.email).to.equal('john@example.com');",
-                  "    pm.expect(responseJson.data.role).to.equal('user');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -5536,15 +4856,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/profile",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "profile"
-              ]
+              "path": ["api", "v1", "profile"]
             }
           },
           "response": []
@@ -5571,7 +4885,7 @@
                   "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('failed');",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
                   "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
@@ -5585,16 +4899,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/profile/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "profile",
-                "applications"
-              ]
+              "path": ["api", "v1", "profile", "applications"]
             }
           },
           "response": []
@@ -5622,7 +4929,12 @@
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
                   "    pm.expect(responseJson.status).to.equal('success');",
-                  "    pm.expect(responseJson.data.applications).to.be.an('array');",
+                  "    pm.expect(responseJson.data.items).to.be.an('array');",
+                  "    pm.expect(responseJson.data.meta).to.be.an('object');",
+                  "    pm.expect(responseJson.data.meta.total).to.be.a('number');",
+                  "    pm.expect(responseJson.data.meta.page).to.be.a('number');",
+                  "    pm.expect(responseJson.data.meta.limit).to.be.a('number');",
+                  "    pm.expect(responseJson.data.meta.totalPages).to.be.a('number');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -5641,16 +4953,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/profile/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "profile",
-                "applications"
-              ]
+              "path": ["api", "v1", "profile", "applications"]
             }
           },
           "response": []
@@ -5677,7 +4982,7 @@
                   "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('failed');",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
                   "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
@@ -5691,16 +4996,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/profile/bookmarks",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "profile",
-                "bookmarks"
-              ]
+              "path": ["api", "v1", "profile", "bookmarks"]
             }
           },
           "response": []
@@ -5728,7 +5026,12 @@
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
                   "    pm.expect(responseJson.status).to.equal('success');",
-                  "    pm.expect(responseJson.data.bookmarks).to.be.an('array');",
+                  "    pm.expect(responseJson.data.items).to.be.an('array');",
+                  "    pm.expect(responseJson.data.meta).to.be.an('object');",
+                  "    pm.expect(responseJson.data.meta.total).to.be.a('number');",
+                  "    pm.expect(responseJson.data.meta.page).to.be.a('number');",
+                  "    pm.expect(responseJson.data.meta.limit).to.be.a('number');",
+                  "    pm.expect(responseJson.data.meta.totalPages).to.be.a('number');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -5747,16 +5050,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/profile/bookmarks",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "profile",
-                "bookmarks"
-              ]
+              "path": ["api", "v1", "profile", "bookmarks"]
             }
           },
           "response": []
@@ -5797,15 +5093,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -5813,7 +5103,7 @@
       ]
     },
     {
-      "name": "[Opsional] Cache",
+      "name": "Cache",
       "item": [
         {
           "name": "[Setup] - Add Company",
@@ -5850,15 +5140,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies"
-              ]
+              "path": ["api", "v1", "companies"]
             }
           },
           "response": []
@@ -5892,15 +5176,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users"
-              ]
+              "path": ["api", "v1", "users"]
             }
           },
           "response": []
@@ -5940,15 +5218,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ]
+              "path": ["api", "v1", "jobs"]
             }
           },
           "response": []
@@ -5988,15 +5260,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications"
-              ]
+              "path": ["api", "v1", "applications"]
             }
           },
           "response": []
@@ -6007,9 +5273,7 @@
             {
               "listen": "test",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript"
               }
             }
@@ -6035,17 +5299,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{jobId}}/bookmark",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{jobId}}",
-                "bookmark"
-              ]
+              "path": ["api", "v1", "jobs", "{{jobId}}", "bookmark"]
             }
           },
           "response": []
@@ -6080,16 +5336,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "{{companyId}}"
-              ]
+              "path": ["api", "v1", "companies", "{{companyId}}"]
             }
           },
           "response": []
@@ -6124,16 +5373,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "{{companyId}}"
-              ]
+              "path": ["api", "v1", "companies", "{{companyId}}"]
             }
           },
           "response": []
@@ -6168,16 +5410,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users/{{newUserId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users",
-                "{{newUserId}}"
-              ]
+              "path": ["api", "v1", "users", "{{newUserId}}"]
             }
           },
           "response": []
@@ -6212,16 +5447,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users/{{newUserId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users",
-                "{{newUserId}}"
-              ]
+              "path": ["api", "v1", "users", "{{newUserId}}"]
             }
           },
           "response": []
@@ -6257,16 +5485,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/{{applicationId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "{{applicationId}}"
-              ]
+              "path": ["api", "v1", "applications", "{{applicationId}}"]
             }
           },
           "response": []
@@ -6302,16 +5523,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/{{applicationId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "{{applicationId}}"
-              ]
+              "path": ["api", "v1", "applications", "{{applicationId}}"]
             }
           },
           "response": []
@@ -6347,17 +5561,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/user/{{userId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "user",
-                "{{userId}}"
-              ]
+              "path": ["api", "v1", "applications", "user", "{{userId}}"]
             }
           },
           "response": []
@@ -6393,17 +5599,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/user/{{userId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "user",
-                "{{userId}}"
-              ]
+              "path": ["api", "v1", "applications", "user", "{{userId}}"]
             }
           },
           "response": []
@@ -6439,9 +5637,7 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/job/{{applicationJobId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
               "path": [
                 "api",
@@ -6485,9 +5681,7 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/job/{{applicationJobId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
               "path": [
                 "api",
@@ -6531,15 +5725,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/bookmarks",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "bookmarks"
-              ]
+              "path": ["api", "v1", "bookmarks"]
             }
           },
           "response": []
@@ -6575,15 +5763,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/bookmarks",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "bookmarks"
-              ]
+              "path": ["api", "v1", "bookmarks"]
             }
           },
           "response": []
@@ -6629,16 +5811,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "{{companyId}}"
-              ]
+              "path": ["api", "v1", "companies", "{{companyId}}"]
             }
           },
           "response": []
@@ -6673,16 +5848,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/{{companyId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "{{companyId}}"
-              ]
+              "path": ["api", "v1", "companies", "{{companyId}}"]
             }
           },
           "response": []
@@ -6722,15 +5890,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ]
+              "path": ["api", "v1", "jobs"]
             }
           },
           "response": []
@@ -6776,15 +5938,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications"
-              ]
+              "path": ["api", "v1", "applications"]
             }
           },
           "response": []
@@ -6827,17 +5983,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/user/{{userId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "user",
-                "{{userId}}"
-              ]
+              "path": ["api", "v1", "applications", "user", "{{userId}}"]
             }
           },
           "response": []
@@ -6878,16 +6026,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/{{newApplicationId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "{{newApplicationId}}"
-              ]
+              "path": ["api", "v1", "applications", "{{newApplicationId}}"]
             }
           },
           "response": []
@@ -6928,16 +6069,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/{{newApplicationId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "{{newApplicationId}}"
-              ]
+              "path": ["api", "v1", "applications", "{{newApplicationId}}"]
             }
           },
           "response": []
@@ -6981,15 +6115,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users"
-              ]
+              "path": ["api", "v1", "users"]
             }
           },
           "response": []
@@ -7028,15 +6156,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/users",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "users"
-              ]
+              "path": ["api", "v1", "users"]
             }
           },
           "response": []
@@ -7074,15 +6196,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -7119,15 +6235,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/authentications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "authentications"
-              ]
+              "path": ["api", "v1", "authentications"]
             }
           },
           "response": []
@@ -7161,15 +6271,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/profile",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "profile"
-              ]
+              "path": ["api", "v1", "profile"]
             }
           },
           "response": []
@@ -7203,15 +6307,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/profile",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "profile"
-              ]
+              "path": ["api", "v1", "profile"]
             }
           },
           "response": []
@@ -7256,15 +6354,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies"
-              ]
+              "path": ["api", "v1", "companies"]
             }
           },
           "response": []
@@ -7306,15 +6398,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories"
-              ]
+              "path": ["api", "v1", "categories"]
             }
           },
           "response": []
@@ -7359,15 +6445,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs"
-              ]
+              "path": ["api", "v1", "jobs"]
             }
           },
           "response": []
@@ -7431,15 +6511,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications"
-              ]
+              "path": ["api", "v1", "applications"]
             }
           },
           "response": []
@@ -7485,15 +6559,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications"
-              ]
+              "path": ["api", "v1", "applications"]
             }
           },
           "response": []
@@ -7534,16 +6602,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/{{mqApplicationId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "{{mqApplicationId}}"
-              ]
+              "path": ["api", "v1", "applications", "{{mqApplicationId}}"]
             }
           },
           "response": []
@@ -7583,15 +6644,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications"
-              ]
+              "path": ["api", "v1", "applications"]
             }
           },
           "response": []
@@ -7636,15 +6691,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications"
-              ]
+              "path": ["api", "v1", "applications"]
             }
           },
           "response": []
@@ -7676,16 +6725,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/applications/{{mqApplicationId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "applications",
-                "{{mqApplicationId}}"
-              ]
+              "path": ["api", "v1", "applications", "{{mqApplicationId}}"]
             }
           },
           "response": []
@@ -7717,16 +6759,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/jobs/{{mqJobId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "jobs",
-                "{{mqJobId}}"
-              ]
+              "path": ["api", "v1", "jobs", "{{mqJobId}}"]
             }
           },
           "response": []
@@ -7758,16 +6793,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/companies/{{mqCompanyId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "companies",
-                "{{mqCompanyId}}"
-              ]
+              "path": ["api", "v1", "companies", "{{mqCompanyId}}"]
             }
           },
           "response": []
@@ -7799,16 +6827,9 @@
             "url": {
               "raw": "http://localhost:{{port}}/api/v1/categories/{{mqCategoryId}}",
               "protocol": "http",
-              "host": [
-                "localhost"
-              ],
+              "host": ["localhost"],
               "port": "{{port}}",
-              "path": [
-                "api",
-                "v1",
-                "categories",
-                "{{mqCategoryId}}"
-              ]
+              "path": ["api", "v1", "categories", "{{mqCategoryId}}"]
             }
           },
           "response": []

--- a/test/postman/OpenJob.postman_environment.json
+++ b/test/postman/OpenJob.postman_environment.json
@@ -3,8 +3,8 @@
   "name": "OpenJob API",
   "values": [
     {
-      "key": "port",
-      "value": "5000",
+      "key": "baseURL",
+      "value": "http://localhost:3000/api/v1",
       "type": "default",
       "enabled": true
     },


### PR DESCRIPTION
## 🔗 Closes
Closes #8

---

## 📋 Summary
Implements a global `JwtAuthGuard` that verifies Bearer access tokens and protects any endpoint decorated with `@UseGuards(JwtAuthGuard)`. Also adds the `@CurrentUser()` param decorator to extract the authenticated user's JWT payload from the request.

On top of that, introduces a new `ProfileModule` with three read-only endpoints:
- `GET /api/v1/profile` — returns the authenticated user's profile data
- `GET /api/v1/profile/applications` — paginated list of the user's job applications
- `GET /api/v1/profile/bookmarks` — paginated list of the user's bookmarked jobs

Pagination uses a shared `PaginationQueryDto` (`page`, `limit`) and returns `{ items, meta: { total, page, limit, totalPages } }`. All endpoints are protected by `JwtAuthGuard` and delegate to `ProfileService`, which reuses `UsersService.findByUuid` for profile lookup.

Postman collection was also updated: Profile assertions were fixed to match the actual API response shape, and all URL objects across the entire collection were migrated from structured objects to plain strings using `{{baseURL}}` variable so Newman can resolve them correctly.

---

## 🔄 Type of Change
- [ ] `chore` — Setup, configuration, tooling
- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `database` — Schema, migration, indexing
- [ ] `docs` — Documentation
- [ ] `refactor` — Refactoring without functional changes
- [x] `test` — Adding or improving tests

---

## ✅ Tasks Completed
- [x] Create `JwtAuthGuard` that extracts and verifies the Bearer access token using `ACCESS_TOKEN_KEY`
- [x] Create `@CurrentUser()` param decorator to extract JWT payload from request
- [x] Create `ProfileModule` with `ProfileController` and `ProfileService`
- [x] `GET /api/v1/profile` — returns authenticated user's profile (delegates to `UsersService.findByUuid`)
- [x] `GET /api/v1/profile/applications` — paginated list of user's job applications
- [x] `GET /api/v1/profile/bookmarks` — paginated list of user's bookmarked jobs
- [x] Unit tests for `JwtAuthGuard` (5 tests)
- [x] Unit tests for `ProfileService` (10 tests)
- [x] Unit tests for `ProfileController` (6 tests)
- [x] E2E tests for profile endpoints (12 tests)
- [x] Postman collection: fix Profile assertions to match API response shape
- [x] Postman collection: migrate all URLs to use `{{baseURL}}` variable (plain string format for Newman compatibility)
- [x] Postman environment: replace `port` variable with `baseURL`

---

## 🎯 Acceptance Criteria Verified
- [x] Unauthenticated requests to profile endpoints return `401 Unauthorized`
- [x] Requests with invalid/expired tokens return `401 Unauthorized` with message `"Invalid or expired access token"`
- [x] Valid Bearer token returns `200 OK` with `{ status: "success", data: { ... } }`
- [x] `GET /profile/applications` and `GET /profile/bookmarks` return paginated response with `data.items` and `data.meta` (`total`, `page`, `limit`, `totalPages`)
- [x] Invalid pagination params (e.g. `page=0`, `limit=abc`) return `400 Bad Request`
- [x] No integer `id` exposed in responses — only UUID

---

## 🧪 How to Test
1. Start infrastructure: `docker compose -f infrastructure/docker-compose.yml up -d`
2. Run migrations + seed: `npx prisma migrate deploy && npx prisma db seed`
3. Start the server: `npm run start:dev`
4. Run unit tests: `npm run test`
5. Run E2E tests: `npm run test:e2e`
6. Run Postman/Newman (full collection with throttle-safe delay):
   ```bash
   npx newman run test/postman/OpenJob.postman_collection.json \
     -e test/postman/OpenJob.postman_environment.json \
     --folder "Users" --folder "Authentications" --folder "Profile" \
     --delay-request 13000
   ```
   > Note: The 13s delay is required because POST `/users` and POST `/authentications` have a strict throttle of 5 req/min by design. Without the delay, you may get 429 responses on rapid reruns.

---

## 🔍 Reviewer Checklist
- [x] Code follows naming conventions (SysDesign §6.1)
- [x] No integer `id` is exposed in the response
- [x] No hardcoded credentials
- [x] Soft delete queries filter `deletedAt IS NULL`
- [x] Response shape matches `{ status, data }` / `{ status, message }`
- [x] All new env vars have been added to `.env.example`