### PR TITLE
[FEAT] Categories module CRUD + soft delete

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { UsersModule } from './modules/users/users.module';
 import { AuthenticationsModule } from './modules/authentications/authentications.module';
 import { ProfileModule } from './modules/profile/profile.module';
 import { CompaniesModule } from './modules/companies/companies.module';
+import { CategoriesModule } from './modules/categories/categories.module';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 import { CustomThrottlerGuard } from './common/guards/throttler.guard';
 import { THROTTLER_LIMITS } from './common/constants/throttler.constants';
@@ -35,6 +36,7 @@ import { THROTTLER_LIMITS } from './common/constants/throttler.constants';
     AuthenticationsModule,
     ProfileModule,
     CompaniesModule,
+    CategoriesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/modules/categories/categories.controller.spec.ts
+++ b/src/modules/categories/categories.controller.spec.ts
@@ -1,0 +1,180 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import type { Response } from 'express';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { CategoryResponseDto } from './dto/category-response.dto';
+import type { PaginatedResult } from '../profile/dto/pagination-query.dto';
+
+const CATEGORY_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+const mockCategoryResponse: CategoryResponseDto = {
+  id: CATEGORY_UUID,
+  name: 'Engineering',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+const mockFindResult = {
+  data: mockCategoryResponse,
+  source: 'database' as const,
+};
+
+const mockPaginatedResult: PaginatedResult<CategoryResponseDto> = {
+  items: [mockCategoryResponse],
+  meta: { total: 1, page: 1, limit: 10, totalPages: 1 },
+};
+
+const mockRes = {
+  header: jest.fn(),
+} as unknown as Response;
+
+describe('CategoriesController', () => {
+  let controller: CategoriesController;
+  let service: jest.Mocked<CategoriesService>;
+
+  beforeEach(async () => {
+    service = {
+      create: jest.fn(),
+      findAll: jest.fn(),
+      findByUuid: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+      invalidateCache: jest.fn(),
+    } as unknown as jest.Mocked<CategoriesService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoriesController],
+      providers: [{ provide: CategoriesService, useValue: service }],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<CategoriesController>(CategoriesController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -----------------------------------------------------------------------
+  // GET /categories
+  // -----------------------------------------------------------------------
+  describe('getAll()', () => {
+    it('should return a paginated list of categories', async () => {
+      service.findAll.mockResolvedValue(mockPaginatedResult);
+
+      const result = await controller.getAll({ page: 1, limit: 10 });
+
+      expect(service.findAll).toHaveBeenCalledWith({ page: 1, limit: 10 });
+      expect(result).toEqual(mockPaginatedResult);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /categories/:uuid
+  // -----------------------------------------------------------------------
+  describe('getById()', () => {
+    it('should return the category and set X-Data-Source header', async () => {
+      service.findByUuid.mockResolvedValue(mockFindResult);
+
+      const result = await controller.getById(CATEGORY_UUID, mockRes);
+
+      expect(service.findByUuid).toHaveBeenCalledWith(CATEGORY_UUID);
+      expect(mockRes.header).toHaveBeenCalledWith('X-Data-Source', 'database');
+      expect(result).toEqual(mockCategoryResponse);
+    });
+
+    it('should set X-Data-Source to "cache" when served from cache', async () => {
+      service.findByUuid.mockResolvedValue({ ...mockFindResult, source: 'cache' });
+
+      await controller.getById(CATEGORY_UUID, mockRes);
+
+      expect(mockRes.header).toHaveBeenCalledWith('X-Data-Source', 'cache');
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      service.findByUuid.mockRejectedValue(new NotFoundException());
+
+      await expect(
+        controller.getById(CATEGORY_UUID, mockRes),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // POST /categories
+  // -----------------------------------------------------------------------
+  describe('create()', () => {
+    const dto: CreateCategoryDto = { name: 'Engineering' };
+
+    it('should create and return a category', async () => {
+      service.create.mockResolvedValue(mockCategoryResponse);
+
+      const result = await controller.create(dto);
+
+      expect(service.create).toHaveBeenCalledWith(dto);
+      expect(result).toEqual(mockCategoryResponse);
+    });
+
+    it('should propagate ConflictException from service', async () => {
+      service.create.mockRejectedValue(new ConflictException());
+
+      await expect(controller.create(dto)).rejects.toThrow(ConflictException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // PUT /categories/:uuid
+  // -----------------------------------------------------------------------
+  describe('update()', () => {
+    const dto: UpdateCategoryDto = { name: 'Design' };
+
+    it('should update and return success message', async () => {
+      service.update.mockResolvedValue(undefined);
+
+      const result = await controller.update(CATEGORY_UUID, dto);
+
+      expect(service.update).toHaveBeenCalledWith(CATEGORY_UUID, dto);
+      expect(result).toEqual({
+        status: 'success',
+        message: 'Category updated successfully',
+      });
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      service.update.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.update(CATEGORY_UUID, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // DELETE /categories/:uuid
+  // -----------------------------------------------------------------------
+  describe('remove()', () => {
+    it('should soft-delete and return success message', async () => {
+      service.remove.mockResolvedValue(undefined);
+
+      const result = await controller.remove(CATEGORY_UUID);
+
+      expect(service.remove).toHaveBeenCalledWith(CATEGORY_UUID);
+      expect(result).toEqual({
+        status: 'success',
+        message: 'Category deleted successfully',
+      });
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      service.remove.mockRejectedValue(new NotFoundException());
+
+      await expect(controller.remove(CATEGORY_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/src/modules/categories/categories.controller.ts
+++ b/src/modules/categories/categories.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { CategoriesService } from './categories.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { CategoryResponseDto } from './dto/category-response.dto';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { SkipTransform } from '../../common/decorators/skip-transform.decorator';
+import {
+  PaginationQueryDto,
+  type PaginatedResult,
+} from '../profile/dto/pagination-query.dto';
+
+@Controller('categories')
+export class CategoriesController {
+  constructor(private readonly categoriesService: CategoriesService) {}
+
+  @Get()
+  getAll(
+    @Query() query: PaginationQueryDto,
+  ): Promise<PaginatedResult<CategoryResponseDto>> {
+    return this.categoriesService.findAll(query);
+  }
+
+  @Get(':uuid')
+  async getById(
+    @Param('uuid') uuid: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<CategoryResponseDto> {
+    const { data, source } = await this.categoriesService.findByUuid(uuid);
+    res.header('X-Data-Source', source);
+    return data;
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UseGuards(JwtAuthGuard)
+  create(@Body() dto: CreateCategoryDto): Promise<CategoryResponseDto> {
+    return this.categoriesService.create(dto);
+  }
+
+  @Put(':uuid')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  @SkipTransform()
+  async update(
+    @Param('uuid') uuid: string,
+    @Body() dto: UpdateCategoryDto,
+  ): Promise<{ status: string; message: string }> {
+    await this.categoriesService.update(uuid, dto);
+    return { status: 'success', message: 'Category updated successfully' };
+  }
+
+  @Delete(':uuid')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  @SkipTransform()
+  async remove(
+    @Param('uuid') uuid: string,
+  ): Promise<{ status: string; message: string }> {
+    await this.categoriesService.remove(uuid);
+    return { status: 'success', message: 'Category deleted successfully' };
+  }
+}

--- a/src/modules/categories/categories.module.ts
+++ b/src/modules/categories/categories.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+
+@Module({
+  imports: [JwtModule.register({})],
+  controllers: [CategoriesController],
+  providers: [CategoriesService, JwtAuthGuard],
+  exports: [CategoriesService],
+})
+export class CategoriesModule {}

--- a/src/modules/categories/categories.service.spec.ts
+++ b/src/modules/categories/categories.service.spec.ts
@@ -1,0 +1,336 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CacheService } from '../cache/cache.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { CategoryResponseDto } from './dto/category-response.dto';
+
+const CATEGORY_UUID = '550e8400-e29b-41d4-a716-446655440000';
+const OTHER_UUID = '999e8400-e29b-41d4-a716-446655440099';
+const INVALID_UUID = 'not-a-valid-uuid';
+
+const mockCategory = {
+  id: 1,
+  uuid: CATEGORY_UUID,
+  name: 'Engineering',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  deletedAt: null,
+};
+
+const mockCategoryResponse: CategoryResponseDto = {
+  id: CATEGORY_UUID,
+  name: 'Engineering',
+  createdAt: mockCategory.createdAt,
+  updatedAt: mockCategory.updatedAt,
+};
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+  let prisma: {
+    client: {
+      category: {
+        findMany: jest.Mock;
+        count: jest.Mock;
+        findUnique: jest.Mock;
+        findFirst: jest.Mock;
+        create: jest.Mock;
+        update: jest.Mock;
+      };
+    };
+  };
+  let cache: jest.Mocked<CacheService>;
+
+  beforeEach(async () => {
+    prisma = {
+      client: {
+        category: {
+          findMany: jest.fn(),
+          count: jest.fn(),
+          findUnique: jest.fn(),
+          findFirst: jest.fn(),
+          create: jest.fn(),
+          update: jest.fn(),
+        },
+      },
+    };
+
+    cache = {
+      get: jest.fn(),
+      set: jest.fn(),
+      del: jest.fn(),
+    } as unknown as jest.Mocked<CacheService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategoriesService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CacheService, useValue: cache },
+      ],
+    }).compile();
+
+    service = module.get<CategoriesService>(CategoriesService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -----------------------------------------------------------------------
+  // create()
+  // -----------------------------------------------------------------------
+  describe('create()', () => {
+    const dto: CreateCategoryDto = { name: 'Engineering' };
+
+    it('should create a category and return CategoryResponseDto', async () => {
+      prisma.client.category.findFirst.mockResolvedValue(null);
+      prisma.client.category.create.mockResolvedValue(mockCategory);
+
+      const result = await service.create(dto);
+
+      expect(prisma.client.category.create).toHaveBeenCalledWith({
+        data: { name: dto.name },
+      });
+      expect(result).toEqual(mockCategoryResponse);
+    });
+
+    it('should throw ConflictException if name already exists', async () => {
+      prisma.client.category.findFirst.mockResolvedValue(mockCategory);
+
+      await expect(service.create(dto)).rejects.toThrow(ConflictException);
+      expect(prisma.client.category.create).not.toHaveBeenCalled();
+    });
+
+    it('should not expose integer id or deletedAt in response', async () => {
+      prisma.client.category.findFirst.mockResolvedValue(null);
+      prisma.client.category.create.mockResolvedValue(mockCategory);
+
+      const result = await service.create(dto);
+
+      expect(result.id).toBe(CATEGORY_UUID);
+      expect(result).not.toHaveProperty('deletedAt');
+      expect(typeof result.id).toBe('string');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findAll()
+  // -----------------------------------------------------------------------
+  describe('findAll()', () => {
+    it('should return a paginated list of categories', async () => {
+      prisma.client.category.findMany.mockResolvedValue([mockCategory]);
+      prisma.client.category.count.mockResolvedValue(1);
+
+      const result = await service.findAll({ page: 1, limit: 10 });
+
+      expect(prisma.client.category.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 0,
+          take: 10,
+          orderBy: { name: 'asc' },
+        }),
+      );
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual(mockCategoryResponse);
+    });
+
+    it('should return correct pagination meta', async () => {
+      prisma.client.category.findMany.mockResolvedValue([mockCategory]);
+      prisma.client.category.count.mockResolvedValue(25);
+
+      const result = await service.findAll({ page: 2, limit: 10 });
+
+      expect(result.meta).toEqual({
+        total: 25,
+        page: 2,
+        limit: 10,
+        totalPages: 3,
+      });
+    });
+
+    it('should use correct skip for page > 1', async () => {
+      prisma.client.category.findMany.mockResolvedValue([]);
+      prisma.client.category.count.mockResolvedValue(0);
+
+      await service.findAll({ page: 3, limit: 5 });
+
+      expect(prisma.client.category.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ skip: 10, take: 5 }),
+      );
+    });
+
+    it('should return empty items and total=0 when no categories exist', async () => {
+      prisma.client.category.findMany.mockResolvedValue([]);
+      prisma.client.category.count.mockResolvedValue(0);
+
+      const result = await service.findAll({ page: 1, limit: 10 });
+
+      expect(result.items).toHaveLength(0);
+      expect(result.meta.total).toBe(0);
+      expect(result.meta.totalPages).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findByUuid()
+  // -----------------------------------------------------------------------
+  describe('findByUuid()', () => {
+    it('should return cached category if present in Redis', async () => {
+      cache.get.mockResolvedValue(mockCategoryResponse);
+
+      const result = await service.findByUuid(CATEGORY_UUID);
+
+      expect(cache.get).toHaveBeenCalledWith(`categories:${CATEGORY_UUID}`);
+      expect(prisma.client.category.findUnique).not.toHaveBeenCalled();
+      expect(result.data).toEqual(mockCategoryResponse);
+      expect(result.source).toBe('cache');
+    });
+
+    it('should fetch from DB and cache result on cache miss', async () => {
+      cache.get.mockResolvedValue(null);
+      prisma.client.category.findUnique.mockResolvedValue(mockCategory);
+      cache.set.mockResolvedValue(undefined);
+
+      const result = await service.findByUuid(CATEGORY_UUID);
+
+      expect(prisma.client.category.findUnique).toHaveBeenCalledWith({
+        where: { uuid: CATEGORY_UUID },
+      });
+      expect(cache.set).toHaveBeenCalledWith(
+        `categories:${CATEGORY_UUID}`,
+        mockCategoryResponse,
+        3600,
+      );
+      expect(result.data).toEqual(mockCategoryResponse);
+      expect(result.source).toBe('database');
+    });
+
+    it('should throw NotFoundException if category does not exist', async () => {
+      cache.get.mockResolvedValue(null);
+      prisma.client.category.findUnique.mockResolvedValue(null);
+
+      await expect(service.findByUuid(CATEGORY_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException for invalid UUID format', async () => {
+      await expect(service.findByUuid(INVALID_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.client.category.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // update()
+  // -----------------------------------------------------------------------
+  describe('update()', () => {
+    const dto: UpdateCategoryDto = { name: 'Design' };
+
+    it('should update a category and invalidate cache', async () => {
+      prisma.client.category.findUnique.mockResolvedValue(mockCategory);
+      prisma.client.category.findFirst.mockResolvedValue(null);
+      prisma.client.category.update.mockResolvedValue({
+        ...mockCategory,
+        name: 'Design',
+      });
+      cache.del.mockResolvedValue(undefined);
+
+      await service.update(CATEGORY_UUID, dto);
+
+      expect(prisma.client.category.update).toHaveBeenCalledWith({
+        where: { id: mockCategory.id },
+        data: { name: dto.name },
+      });
+      expect(cache.del).toHaveBeenCalledWith(`categories:${CATEGORY_UUID}`);
+    });
+
+    it('should throw NotFoundException when category does not exist', async () => {
+      prisma.client.category.findUnique.mockResolvedValue(null);
+
+      await expect(service.update(CATEGORY_UUID, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException for invalid UUID format', async () => {
+      await expect(service.update(INVALID_UUID, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ConflictException when name is taken by another category', async () => {
+      prisma.client.category.findUnique.mockResolvedValue(mockCategory);
+      prisma.client.category.findFirst.mockResolvedValue({
+        ...mockCategory,
+        uuid: OTHER_UUID,
+      });
+
+      await expect(service.update(CATEGORY_UUID, dto)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(prisma.client.category.update).not.toHaveBeenCalled();
+    });
+
+    it('should allow update when the matching name belongs to the same category', async () => {
+      prisma.client.category.findUnique.mockResolvedValue(mockCategory);
+      prisma.client.category.findFirst.mockResolvedValue(mockCategory); // same uuid
+      prisma.client.category.update.mockResolvedValue(mockCategory);
+      cache.del.mockResolvedValue(undefined);
+
+      await expect(
+        service.update(CATEGORY_UUID, { name: mockCategory.name }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // remove()
+  // -----------------------------------------------------------------------
+  describe('remove()', () => {
+    it('should soft-delete a category and invalidate cache', async () => {
+      prisma.client.category.findUnique.mockResolvedValue(mockCategory);
+      prisma.client.category.update.mockResolvedValue({
+        ...mockCategory,
+        deletedAt: new Date(),
+      });
+      cache.del.mockResolvedValue(undefined);
+
+      await service.remove(CATEGORY_UUID);
+
+      expect(prisma.client.category.update).toHaveBeenCalledWith({
+        where: { id: mockCategory.id },
+        data: { deletedAt: expect.any(Date) },
+      });
+      expect(cache.del).toHaveBeenCalledWith(`categories:${CATEGORY_UUID}`);
+    });
+
+    it('should throw NotFoundException when category does not exist', async () => {
+      prisma.client.category.findUnique.mockResolvedValue(null);
+
+      await expect(service.remove(CATEGORY_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException for invalid UUID format', async () => {
+      await expect(service.remove(INVALID_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // invalidateCache()
+  // -----------------------------------------------------------------------
+  describe('invalidateCache()', () => {
+    it('should call cache.del with the correct key', async () => {
+      cache.del.mockResolvedValue(undefined);
+
+      await service.invalidateCache(CATEGORY_UUID);
+
+      expect(cache.del).toHaveBeenCalledWith(`categories:${CATEGORY_UUID}`);
+    });
+  });
+});

--- a/src/modules/categories/categories.service.ts
+++ b/src/modules/categories/categories.service.ts
@@ -1,0 +1,155 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import type { Category } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CacheService } from '../cache/cache.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { CategoryResponseDto } from './dto/category-response.dto';
+import type {
+  PaginatedResult,
+  PaginationQueryDto,
+} from '../profile/dto/pagination-query.dto';
+
+const CACHE_TTL = 3600; // 1 hour
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const cacheKey = (uuid: string) => `categories:${uuid}`;
+
+export type FindByUuidResult = {
+  data: CategoryResponseDto;
+  source: 'cache' | 'database';
+};
+
+@Injectable()
+export class CategoriesService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cache: CacheService,
+  ) {}
+
+  async create(dto: CreateCategoryDto): Promise<CategoryResponseDto> {
+    const existing = await this.prisma.client.category.findFirst({
+      where: { name: dto.name },
+    });
+    if (existing) {
+      throw new ConflictException('Category with this name already exists');
+    }
+
+    const category = await this.prisma.client.category.create({
+      data: { name: dto.name },
+    });
+    return this.toResponse(category);
+  }
+
+  async findAll(
+    query: PaginationQueryDto,
+  ): Promise<PaginatedResult<CategoryResponseDto>> {
+    const { page, limit } = query;
+    const skip = (page - 1) * limit;
+
+    const [categories, total] = await Promise.all([
+      this.prisma.client.category.findMany({
+        skip,
+        take: limit,
+        orderBy: { name: 'asc' },
+      }),
+      this.prisma.client.category.count(),
+    ]);
+
+    return {
+      items: categories.map((c) => this.toResponse(c)),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async findByUuid(uuid: string): Promise<FindByUuidResult> {
+    if (!UUID_REGEX.test(uuid)) {
+      throw new NotFoundException('Category not found');
+    }
+
+    const cached = await this.cache.get<CategoryResponseDto>(cacheKey(uuid));
+    if (cached) return { data: cached, source: 'cache' };
+
+    const category = await this.prisma.client.category.findUnique({
+      where: { uuid },
+    });
+
+    if (!category) {
+      throw new NotFoundException('Category not found');
+    }
+
+    const response = this.toResponse(category);
+    await this.cache.set(cacheKey(uuid), response, CACHE_TTL);
+    return { data: response, source: 'database' };
+  }
+
+  async update(uuid: string, dto: UpdateCategoryDto): Promise<void> {
+    const category = await this.findCategoryOrFail(uuid);
+
+    if (dto.name) {
+      const conflict = await this.prisma.client.category.findFirst({
+        where: { name: dto.name },
+      });
+      if (conflict && conflict.uuid !== uuid) {
+        throw new ConflictException('Category with this name already exists');
+      }
+    }
+
+    await this.prisma.client.category.update({
+      where: { id: category.id },
+      data: { name: dto.name },
+    });
+
+    await this.invalidateCache(uuid);
+  }
+
+  async remove(uuid: string): Promise<void> {
+    const category = await this.findCategoryOrFail(uuid);
+
+    await this.prisma.client.category.update({
+      where: { id: category.id },
+      data: { deletedAt: new Date() },
+    });
+
+    await this.invalidateCache(uuid);
+  }
+
+  async invalidateCache(uuid: string): Promise<void> {
+    await this.cache.del(cacheKey(uuid));
+  }
+
+  private async findCategoryOrFail(uuid: string): Promise<Category> {
+    if (!UUID_REGEX.test(uuid)) {
+      throw new NotFoundException('Category not found');
+    }
+
+    const category = await this.prisma.client.category.findUnique({
+      where: { uuid },
+    });
+
+    if (!category) {
+      throw new NotFoundException('Category not found');
+    }
+
+    return category;
+  }
+
+  private toResponse(category: Category): CategoryResponseDto {
+    return {
+      id: category.uuid,
+      name: category.name,
+      createdAt: category.createdAt,
+      updatedAt: category.updatedAt,
+    };
+  }
+}

--- a/src/modules/categories/dto/category-response.dto.ts
+++ b/src/modules/categories/dto/category-response.dto.ts
@@ -1,0 +1,6 @@
+export class CategoryResponseDto {
+  id!: string; // UUID
+  name!: string;
+  createdAt!: Date;
+  updatedAt!: Date;
+}

--- a/src/modules/categories/dto/create-category.dto.ts
+++ b/src/modules/categories/dto/create-category.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateCategoryDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name!: string;
+}

--- a/src/modules/categories/dto/update-category.dto.ts
+++ b/src/modules/categories/dto/update-category.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateCategoryDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name?: string;
+}

--- a/test/e2e/categories.e2e-spec.ts
+++ b/test/e2e/categories.e2e-spec.ts
@@ -1,0 +1,552 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { ThrottlerStorage } from '@nestjs/throttler';
+import { AppModule } from '../../src/app.module';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { CacheService } from '../../src/modules/cache/cache.service';
+import { AllExceptionsFilter } from '../../src/common/filters/all-exceptions.filter';
+
+const getRandomString = () => Math.random().toString(36).substring(7);
+
+const makeUser = () => ({
+  fullname: `Category Admin ${getRandomString()}`,
+  email: `admin_${getRandomString()}@example.com`,
+  password: 'StrongPassword123!',
+});
+
+const makeCategoryPayload = () => ({ name: `Category ${getRandomString()}` });
+
+async function loginUser(
+  app: INestApplication<App>,
+  email: string,
+  password: string,
+): Promise<string> {
+  const res = await request(app.getHttpServer())
+    .post('/api/v1/authentications')
+    .send({ email, password })
+    .expect(201);
+  return res.body.data.accessToken as string;
+}
+
+describe('CategoriesController (e2e)', () => {
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let cache: CacheService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(ThrottlerStorage)
+      .useValue({
+        increment: jest.fn().mockResolvedValue({
+          totalHits: 0,
+          timeToExpire: 9999,
+          isBlocked: false,
+          timeToBlockExpire: 0,
+        }),
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api/v1');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalFilters(new AllExceptionsFilter());
+
+    prisma = moduleFixture.get(PrismaService);
+    cache = moduleFixture.get(CacheService);
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await prisma.client.category.deleteMany({});
+    await prisma.client.authentication.deleteMany({});
+    await prisma.client.user.deleteMany({});
+    await app.close();
+  });
+
+  afterEach(async () => {
+    await prisma.client.category.deleteMany({});
+    await prisma.client.authentication.deleteMany({});
+    await prisma.client.user.deleteMany({});
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/categories
+  // -----------------------------------------------------------------------
+  describe('GET /api/v1/categories', () => {
+    it('should return paginated list of categories (public)', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(makeCategoryPayload())
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/categories')
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.items).toBeInstanceOf(Array);
+      expect(res.body.data.items.length).toBeGreaterThanOrEqual(1);
+      expect(res.body.data.meta).toHaveProperty('total');
+      expect(res.body.data.meta).toHaveProperty('page');
+      expect(res.body.data.meta).toHaveProperty('limit');
+      expect(res.body.data.meta).toHaveProperty('totalPages');
+    });
+
+    it('should not include soft-deleted categories in the list', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      const createRes = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(makeCategoryPayload())
+        .expect(201);
+
+      const uuid: string = createRes.body.data.id;
+
+      await request(app.getHttpServer())
+        .delete(`/api/v1/categories/${uuid}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      const listRes = await request(app.getHttpServer())
+        .get('/api/v1/categories')
+        .expect(200);
+
+      const ids: string[] = listRes.body.data.items.map(
+        (c: { id: string }) => c.id,
+      );
+      expect(ids).not.toContain(uuid);
+    });
+
+    it('should respect pagination params', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      for (let i = 0; i < 3; i++) {
+        await request(app.getHttpServer())
+          .post('/api/v1/categories')
+          .set('Authorization', `Bearer ${token}`)
+          .send(makeCategoryPayload())
+          .expect(201);
+      }
+
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/categories?page=1&limit=2')
+        .expect(200);
+
+      expect(res.body.data.items).toHaveLength(2);
+      expect(res.body.data.meta.limit).toBe(2);
+      expect(res.body.data.meta.totalPages).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should not expose integer id in list items', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(makeCategoryPayload())
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/categories')
+        .expect(200);
+
+      const item = res.body.data.items[0];
+      expect(item.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+      expect(item).not.toHaveProperty('deletedAt');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // POST /api/v1/categories
+  // -----------------------------------------------------------------------
+  describe('POST /api/v1/categories', () => {
+    it('should create a category for authenticated user', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+      const payload = makeCategoryPayload();
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(payload)
+        .expect(201);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+      expect(res.body.data.name).toBe(payload.name);
+      expect(res.body.data).not.toHaveProperty('deletedAt');
+    });
+
+    it('should return 401 when no token is provided', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .send(makeCategoryPayload())
+        .expect(401);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should return 400 when name is missing', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send({})
+        .expect(400);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should return 409 when name already exists', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+      const payload = makeCategoryPayload();
+
+      await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(payload)
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(payload)
+        .expect(409);
+
+      expect(res.body.status).toBe('fail');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/categories/:uuid
+  // -----------------------------------------------------------------------
+  describe('GET /api/v1/categories/:uuid', () => {
+    it('should return category details and cache the second hit', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      const createRes = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(makeCategoryPayload())
+        .expect(201);
+
+      const uuid: string = createRes.body.data.id;
+      await cache.del(`categories:${uuid}`);
+
+      // First hit -> database
+      const first = await request(app.getHttpServer())
+        .get(`/api/v1/categories/${uuid}`)
+        .expect(200);
+
+      expect(first.headers['x-data-source']).toBe('database');
+      expect(first.body.data.id).toBe(uuid);
+      expect(first.body.data).not.toHaveProperty('deletedAt');
+
+      // Second hit -> cache
+      const second = await request(app.getHttpServer())
+        .get(`/api/v1/categories/${uuid}`)
+        .expect(200);
+
+      expect(second.headers['x-data-source']).toBe('cache');
+      expect(second.body.data.id).toBe(uuid);
+    });
+
+    it('should return 404 for invalid UUID format', async () => {
+      await request(app.getHttpServer())
+        .get('/api/v1/categories/not-a-uuid')
+        .expect(404);
+    });
+
+    it('should return 404 for soft-deleted category', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      const createRes = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(makeCategoryPayload())
+        .expect(201);
+
+      const uuid: string = createRes.body.data.id;
+
+      await request(app.getHttpServer())
+        .delete(`/api/v1/categories/${uuid}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      await request(app.getHttpServer())
+        .get(`/api/v1/categories/${uuid}`)
+        .expect(404);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // PUT /api/v1/categories/:uuid
+  // -----------------------------------------------------------------------
+  describe('PUT /api/v1/categories/:uuid', () => {
+    it('should update category when authenticated', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      const createRes = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(makeCategoryPayload())
+        .expect(201);
+
+      const uuid: string = createRes.body.data.id;
+
+      const res = await request(app.getHttpServer())
+        .put(`/api/v1/categories/${uuid}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: `Updated ${getRandomString()}` })
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.message).toBe('Category updated successfully');
+    });
+
+    it('should return 401 when no token is provided', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      const createRes = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(makeCategoryPayload())
+        .expect(201);
+
+      const uuid: string = createRes.body.data.id;
+
+      await request(app.getHttpServer())
+        .put(`/api/v1/categories/${uuid}`)
+        .send({ name: 'No Token' })
+        .expect(401);
+    });
+
+    it('should return 404 when category does not exist', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      await request(app.getHttpServer())
+        .put('/api/v1/categories/00000000-0000-4000-a000-000000000000')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: 'Ghost' })
+        .expect(404);
+    });
+
+    it('should return 409 when updated name conflicts with another category', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      const firstPayload = makeCategoryPayload();
+      const secondPayload = makeCategoryPayload();
+
+      await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(firstPayload)
+        .expect(201);
+
+      const secondRes = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(secondPayload)
+        .expect(201);
+
+      const uuid: string = secondRes.body.data.id;
+
+      const res = await request(app.getHttpServer())
+        .put(`/api/v1/categories/${uuid}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: firstPayload.name })
+        .expect(409);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should invalidate cache after update', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      const createRes = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(makeCategoryPayload())
+        .expect(201);
+
+      const uuid: string = createRes.body.data.id;
+
+      // Warm up cache
+      await request(app.getHttpServer())
+        .get(`/api/v1/categories/${uuid}`)
+        .expect(200);
+
+      await request(app.getHttpServer())
+        .put(`/api/v1/categories/${uuid}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ name: `Updated ${getRandomString()}` })
+        .expect(200);
+
+      // Next GET must hit database
+      const res = await request(app.getHttpServer())
+        .get(`/api/v1/categories/${uuid}`)
+        .expect(200);
+
+      expect(res.headers['x-data-source']).toBe('database');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // DELETE /api/v1/categories/:uuid
+  // -----------------------------------------------------------------------
+  describe('DELETE /api/v1/categories/:uuid', () => {
+    it('should soft-delete category when authenticated', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      const createRes = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(makeCategoryPayload())
+        .expect(201);
+
+      const uuid: string = createRes.body.data.id;
+
+      const res = await request(app.getHttpServer())
+        .delete(`/api/v1/categories/${uuid}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.message).toBe('Category deleted successfully');
+
+      // Subsequent GET should 404
+      await request(app.getHttpServer())
+        .get(`/api/v1/categories/${uuid}`)
+        .expect(404);
+    });
+
+    it('should return 401 when no token is provided', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      const createRes = await request(app.getHttpServer())
+        .post('/api/v1/categories')
+        .set('Authorization', `Bearer ${token}`)
+        .send(makeCategoryPayload())
+        .expect(201);
+
+      const uuid: string = createRes.body.data.id;
+
+      await request(app.getHttpServer())
+        .delete(`/api/v1/categories/${uuid}`)
+        .expect(401);
+    });
+
+    it('should return 404 when category does not exist', async () => {
+      const user = makeUser();
+      await request(app.getHttpServer())
+        .post('/api/v1/users')
+        .send(user)
+        .expect(201);
+      const token = await loginUser(app, user.email, user.password);
+
+      await request(app.getHttpServer())
+        .delete('/api/v1/categories/00000000-0000-4000-a000-000000000000')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+    });
+  });
+});

--- a/test/postman/OpenJob.postman_collection.json
+++ b/test/postman/OpenJob.postman_collection.json
@@ -1074,6 +1074,82 @@
       "name": "Categories",
       "item": [
         {
+          "name": "[Setup] Register User",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const ts = Date.now();",
+                  "pm.environment.set('categoryTestEmail', `cattest_${ts}@example.com`);"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('user registered successfully', () => {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([201, 409]);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"fullname\": \"Category Tester\",\n    \"email\": \"{{categoryTestEmail}}\",\n    \"password\": \"password123\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseURL}}/users"
+          },
+          "response": []
+        },
+        {
+          "name": "[Setup] Login for Auth Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('login successful', () => {",
+                  "    pm.expect(pm.response).to.have.status(201);",
+                  "});",
+                  "",
+                  "const responseJson = pm.response.json();",
+                  "pm.environment.set('accessToken', responseJson.data.accessToken);",
+                  "pm.environment.set('refreshToken', responseJson.data.refreshToken);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"email\": \"{{categoryTestEmail}}\",\n    \"password\": \"password123\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseURL}}/authentications"
+          },
+          "response": []
+        },
+        {
           "name": "Add Category without Authentication",
           "event": [
             {
@@ -1095,7 +1171,7 @@
                   "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('failed');",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
                   "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
@@ -1141,7 +1217,7 @@
                   "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('failed');",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
                   "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
@@ -1187,7 +1263,7 @@
                   "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('failed');",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
                   "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
@@ -1212,16 +1288,13 @@
                   "let badCategoryPayloads = pm.environment.get('badCategoryPayloads');",
                   "",
                   "if (!badCategoryPayloads || badCategoryPayloads.length === 0) {",
-                  "    badCategoryPayloads = [",
-                  "        {},",
-                  "        { name: 123 },",
-                  "        { name: '' }",
-                  "    ]",
+                  "    badCategoryPayloads = JSON.stringify([{}, { name: 123 }, { name: '' }]);",
                   "}",
                   "",
-                  "const currentBadCategoryPayload = badCategoryPayloads.shift();",
-                  "pm.environment.set('currentBadCategoryPayload', JSON.stringify(currentBadCategoryPayload));",
-                  "pm.environment.set('badCategoryPayloads', badCategoryPayloads);"
+                  "const payloads = JSON.parse(badCategoryPayloads);",
+                  "const current = payloads.shift();",
+                  "pm.environment.set('currentBadCategoryPayload', JSON.stringify(current));",
+                  "pm.environment.set('badCategoryPayloads', JSON.stringify(payloads));"
                 ],
                 "type": "text/javascript"
               }
@@ -1234,16 +1307,23 @@
                   "    pm.expect(pm.response).to.have.status(400);",
                   "});",
                   "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('failed');",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
                   "    pm.expect(responseJson.message).to.be.a('string');",
                   "});",
                   "",
                   "const repeatRequestUntilDatasetEmpty = () => {",
-                  "    const badCategoryPayloads = pm.environment.get('badCategoryPayloads');",
-                  "    if(badCategoryPayloads && badCategoryPayloads.length > 0) {",
-                  "        postman.setNextRequest('Add Category with Invalid Payload');",
+                  "    const remaining = pm.environment.get('badCategoryPayloads');",
+                  "    if (remaining) {",
+                  "        const arr = JSON.parse(remaining);",
+                  "        if (arr.length > 0) {",
+                  "            pm.execution.setNextRequest('Add Category with Invalid Payload');",
+                  "        }",
                   "    }",
                   "};",
                   "",
@@ -1286,9 +1366,13 @@
                   "    pm.expect(pm.response).to.have.status(404);",
                   "});",
                   "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('failed');",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
                   "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
@@ -1312,6 +1396,16 @@
                 "exec": [
                   "pm.test('it should response 404 status code', () => {",
                   "    pm.expect(pm.response).to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
+                  "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1349,6 +1443,16 @@
                 "exec": [
                   "pm.test('it should response 404 status code', () => {",
                   "    pm.expect(pm.response).to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
+                  "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1372,6 +1476,16 @@
           "name": "Add Category with Valid Payload",
           "event": [
             {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const ts = Date.now();",
+                  "pm.environment.set('testCategoryName', 'Test Category ' + ts);"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
               "listen": "test",
               "script": {
                 "exec": [
@@ -1379,10 +1493,16 @@
                   "    pm.expect(pm.response).to.have.status(201);",
                   "});",
                   "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
                   "    pm.expect(responseJson.status).to.equal('success');",
                   "    pm.expect(responseJson.data.id).to.be.a('string');",
+                  "    pm.expect(responseJson.data.name).to.equal(pm.environment.get('testCategoryName'));",
+                  "    pm.expect(responseJson.data).to.not.have.property('deletedAt');",
                   "    pm.environment.set('categoryId', responseJson.data.id);",
                   "});"
                 ],
@@ -1401,7 +1521,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"name\": \"Software Engineering\"\n}",
+              "raw": "{\n    \"name\": \"{{testCategoryName}}\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1423,10 +1543,19 @@
                   "    pm.expect(pm.response).to.have.status(200);",
                   "});",
                   "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
                   "    pm.expect(responseJson.status).to.equal('success');",
-                  "    pm.expect(responseJson.data.categories).to.be.an('array');",
+                  "    pm.expect(responseJson.data.items).to.be.an('array');",
+                  "    pm.expect(responseJson.data.meta).to.be.an('object');",
+                  "    pm.expect(responseJson.data.meta).to.have.property('total');",
+                  "    pm.expect(responseJson.data.meta).to.have.property('page');",
+                  "    pm.expect(responseJson.data.meta).to.have.property('limit');",
+                  "    pm.expect(responseJson.data.meta).to.have.property('totalPages');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1451,10 +1580,16 @@
                   "    pm.expect(pm.response).to.have.status(200);",
                   "});",
                   "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
                   "    pm.expect(responseJson.status).to.equal('success');",
-                  "    pm.expect(responseJson.data.name).to.equal('Software Engineering');",
+                  "    pm.expect(responseJson.data.id).to.equal(pm.environment.get('categoryId'));",
+                  "    pm.expect(responseJson.data.name).to.equal(pm.environment.get('testCategoryName'));",
+                  "    pm.expect(responseJson.data).to.not.have.property('deletedAt');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1477,6 +1612,16 @@
                 "exec": [
                   "pm.test('it should response 200 status code', () => {",
                   "    pm.expect(pm.response).to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal('success');",
+                  "    pm.expect(responseJson.message).to.equal('Category updated successfully');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1514,6 +1659,16 @@
                 "exec": [
                   "pm.test('it should response 200 status code', () => {",
                   "    pm.expect(pm.response).to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal('success');",
+                  "    pm.expect(responseJson.message).to.equal('Category deleted successfully');",
                   "});"
                 ],
                 "type": "text/javascript"

--- a/test/postman/OpenJob.postman_environment.json
+++ b/test/postman/OpenJob.postman_environment.json
@@ -247,6 +247,12 @@
       "value": "",
       "type": "any",
       "enabled": true
+    },
+    {
+      "key": "testCategoryName",
+      "value": "",
+      "type": "any",
+      "enabled": true
     }
   ],
   "_postman_variable_scope": "environment",


### PR DESCRIPTION
## 🔗 Closes
Closes #10

---

## 📋 Summary

Implementasi `CategoriesModule` lengkap dengan Clean Architecture — DTOs, Service, Controller — mengikuti pola yang sudah ada di `CompaniesModule`.

**Keputusan teknis:**
- Dual-ID strategy: integer `id` untuk relasi internal, UUID (`uuid`) diekspos ke luar sebagai `id` pada response — mencegah IDOR
- Cache-aside pattern di `findByUuid`: Redis TTL 1 jam, di-invalidate saat update/delete. Response `GET /categories/:uuid` menyertakan `X-Data-Source: cache | database`
- Soft delete via Prisma extension (`soft-delete.extension.ts`) — query `findMany` / `findFirst` / `findUnique` otomatis filter `deletedAt IS NULL`
- `POST /categories` cek duplikasi nama sebelum insert → `409 Conflict`
- Pagination via shared `PaginationQueryDto` (page, limit) — response: `{ items, meta: { total, page, limit, totalPages } }`

---

## 🔄 Type of Change
- [ ] `chore` — Setup, configuration, tooling
- [x] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `database` — Schema, migration, indexing
- [ ] `docs` — Documentation
- [ ] `refactor` — Refactoring without functional changes
- [x] `test` — Adding or improving tests

---

## ✅ Tasks Completed
- [x] Buat `CategoriesModule` dengan `CategoriesController`, `CategoriesService`, DTOs
- [x] `GET /categories` — list all (paginated), public
- [x] `GET /categories/:id` — detail by UUID, public
- [x] `POST /categories` — create, protected
- [x] `PUT /categories/:id` — update, protected
- [x] `DELETE /categories/:id` — soft delete, protected

---

## 🎯 Acceptance Criteria Verified
- [x] `GET /categories` mengembalikan list categories yang belum soft-deleted dengan pagination
- [x] `GET /categories/:uuid` yang sudah soft-deleted mengembalikan `404`
- [x] `POST /categories` tanpa token mengembalikan `401`
- [x] `DELETE /categories/:uuid` menyebabkan category tidak muncul di `GET /categories`
- [x] Response tidak mengandung integer `id`

---

## 🧪 How to Test

**Unit tests:**
```bash
npx jest --testPathPattern="categories" --verbose
```

**E2E tests:**
```bash
npx jest --config test/e2e/jest-e2e.json --testPathPattern="categories" --verbose
```

**Newman (Postman collection):**
```bash
# Pastikan server dan Docker (PostgreSQL + Redis) berjalan
npx newman run test/postman/OpenJob.postman_collection.json \
  -e test/postman/OpenJob.postman_environment.json \
  --folder "Categories"
```

---

## 🔍 Reviewer Checklist
- [x] Code follows naming conventions (SysDesign §6.1)
- [x] No integer `id` is exposed in the response
- [x] No hardcoded credentials
- [x] Soft delete queries filter `deletedAt IS NULL`
- [x] Response shape matches `{ status, data }` / `{ status, message }`
- [ ] All new env vars have been added to `.env.example`