### PR TITLE
feat(bookmarks): implement Bookmarks module with Redis caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/e2e/jest-e2e.json",
+    "test:newman": "newman run test/postman/OpenJob.postman_collection.json -e test/postman/OpenJob.postman_environment.json",
     "prisma:generate": "prisma generate --schema=src/prisma/schema.prisma",
     "prisma:migrate:dev": "prisma migrate dev --schema=src/prisma/schema.prisma",
     "prisma:migrate:deploy": "prisma migrate deploy --schema=src/prisma/schema.prisma",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { CompaniesModule } from './modules/companies/companies.module';
 import { CategoriesModule } from './modules/categories/categories.module';
 import { JobsModule } from './modules/jobs/jobs.module';
 import { ApplicationsModule } from './modules/applications/applications.module';
+import { BookmarksModule } from './modules/bookmarks/bookmarks.module';
 import { QueueModule } from './modules/queue/queue.module';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 import { CustomThrottlerGuard } from './common/guards/throttler.guard';
@@ -48,6 +49,7 @@ import { THROTTLER_LIMITS } from './common/constants/throttler.constants';
     JobsModule,
     QueueModule,
     ApplicationsModule,
+    BookmarksModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/modules/applications/applications.controller.spec.ts
+++ b/src/modules/applications/applications.controller.spec.ts
@@ -209,10 +209,15 @@ describe('ApplicationsController', () => {
       service.findByUser.mockRejectedValue(new ForbiddenException('Self only'));
 
       await expect(
-        controller.getByUser(APPLICANT_UUID, mockOwnerUser, {
-          page: 1,
-          limit: 10,
-        }, mockRes),
+        controller.getByUser(
+          APPLICANT_UUID,
+          mockOwnerUser,
+          {
+            page: 1,
+            limit: 10,
+          },
+          mockRes,
+        ),
       ).rejects.toThrow(ForbiddenException);
     });
   });
@@ -248,10 +253,15 @@ describe('ApplicationsController', () => {
       );
 
       await expect(
-        controller.getByJob(JOB_UUID, mockApplicantUser, {
-          page: 1,
-          limit: 10,
-        }, mockRes),
+        controller.getByJob(
+          JOB_UUID,
+          mockApplicantUser,
+          {
+            page: 1,
+            limit: 10,
+          },
+          mockRes,
+        ),
       ).rejects.toThrow(ForbiddenException);
     });
   });

--- a/src/modules/applications/applications.service.ts
+++ b/src/modules/applications/applications.service.ts
@@ -233,9 +233,9 @@ export class ApplicationsService {
     }
 
     const { page, limit } = query;
-    const cached = await this.cache.get<PaginatedResult<ApplicationResponseDto>>(
-      userCacheKey(targetUserUuid, page, limit),
-    );
+    const cached = await this.cache.get<
+      PaginatedResult<ApplicationResponseDto>
+    >(userCacheKey(targetUserUuid, page, limit));
     if (cached) return { data: cached, source: 'cache' };
 
     const user = await this.prisma.client.user.findUnique({
@@ -308,9 +308,9 @@ export class ApplicationsService {
     }
 
     const { page, limit } = query;
-    const cached = await this.cache.get<PaginatedResult<ApplicationResponseDto>>(
-      jobCacheKey(jobUuid, page, limit),
-    );
+    const cached = await this.cache.get<
+      PaginatedResult<ApplicationResponseDto>
+    >(jobCacheKey(jobUuid, page, limit));
     if (cached) return { data: cached, source: 'cache' };
     const skip = (page - 1) * limit;
 
@@ -342,11 +342,7 @@ export class ApplicationsService {
       },
     };
 
-    await this.cache.set(
-      jobCacheKey(jobUuid, page, limit),
-      result,
-      CACHE_TTL,
-    );
+    await this.cache.set(jobCacheKey(jobUuid, page, limit), result, CACHE_TTL);
     return { data: result, source: 'database' };
   }
 

--- a/src/modules/bookmarks/bookmarks.controller.spec.ts
+++ b/src/modules/bookmarks/bookmarks.controller.spec.ts
@@ -129,9 +129,17 @@ describe('BookmarksController', () => {
     it('should call service.findByUuid and return BookmarkResponseDto', async () => {
       service.findByUuid.mockResolvedValue(mockBookmarkResponse);
 
-      const result = await controller.findOne(mockUser, JOB_UUID, BOOKMARK_UUID);
+      const result = await controller.findOne(
+        mockUser,
+        JOB_UUID,
+        BOOKMARK_UUID,
+      );
 
-      expect(service.findByUuid).toHaveBeenCalledWith(BOOKMARK_UUID, JOB_UUID, USER_UUID);
+      expect(service.findByUuid).toHaveBeenCalledWith(
+        BOOKMARK_UUID,
+        JOB_UUID,
+        USER_UUID,
+      );
       expect(result).toEqual(mockBookmarkResponse);
     });
 
@@ -146,9 +154,7 @@ describe('BookmarksController', () => {
     });
 
     it('should propagate ForbiddenException from service', async () => {
-      service.findByUuid.mockRejectedValue(
-        new ForbiddenException('No access'),
-      );
+      service.findByUuid.mockRejectedValue(new ForbiddenException('No access'));
 
       await expect(
         controller.findOne(mockUser, JOB_UUID, BOOKMARK_UUID),

--- a/src/modules/bookmarks/bookmarks.controller.spec.ts
+++ b/src/modules/bookmarks/bookmarks.controller.spec.ts
@@ -1,0 +1,204 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { BookmarksController } from './bookmarks.controller';
+import { BookmarksService } from './bookmarks.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import type { JwtPayload } from '../../common/guards/jwt-auth.guard';
+import { BookmarkResponseDto } from './dto/bookmark-response.dto';
+import type { PaginatedResult } from '../profile/dto/pagination-query.dto';
+
+const USER_UUID = '111e8400-e29b-41d4-a716-446655440001';
+const JOB_UUID = '330e8400-e29b-41d4-a716-446655440003';
+const BOOKMARK_UUID = '440e8400-e29b-41d4-a716-446655440004';
+
+const mockUser: JwtPayload = { id: USER_UUID };
+
+const mockBookmarkResponse: BookmarkResponseDto = {
+  id: BOOKMARK_UUID,
+  jobId: JOB_UUID,
+  userId: USER_UUID,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+const mockPaginatedResult: PaginatedResult<BookmarkResponseDto> = {
+  items: [mockBookmarkResponse],
+  meta: { total: 1, page: 1, limit: 10, totalPages: 1 },
+};
+
+const mockRes = {
+  header: jest.fn(),
+} as unknown as Response;
+
+describe('BookmarksController', () => {
+  let controller: BookmarksController;
+  let service: jest.Mocked<BookmarksService>;
+
+  beforeEach(async () => {
+    service = {
+      create: jest.fn(),
+      remove: jest.fn(),
+      findByUuid: jest.fn(),
+      findAll: jest.fn(),
+    } as unknown as jest.Mocked<BookmarksService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BookmarksController],
+      providers: [
+        { provide: BookmarksService, useValue: service },
+        { provide: JwtAuthGuard, useValue: { canActivate: () => true } },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<BookmarksController>(BookmarksController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -----------------------------------------------------------------------
+  // POST /jobs/:jobId/bookmark
+  // -----------------------------------------------------------------------
+  describe('create()', () => {
+    it('should call service.create and return BookmarkResponseDto', async () => {
+      service.create.mockResolvedValue(mockBookmarkResponse);
+
+      const result = await controller.create(mockUser, JOB_UUID);
+
+      expect(service.create).toHaveBeenCalledWith(USER_UUID, JOB_UUID);
+      expect(result).toEqual(mockBookmarkResponse);
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      service.create.mockRejectedValue(new NotFoundException('Job not found'));
+
+      await expect(controller.create(mockUser, JOB_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should propagate ConflictException from service', async () => {
+      service.create.mockRejectedValue(
+        new ConflictException('Already bookmarked'),
+      );
+
+      await expect(controller.create(mockUser, JOB_UUID)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // DELETE /jobs/:jobId/bookmark
+  // -----------------------------------------------------------------------
+  describe('remove()', () => {
+    it('should call service.remove and return success message', async () => {
+      service.remove.mockResolvedValue(undefined);
+
+      const result = await controller.remove(mockUser, JOB_UUID);
+
+      expect(service.remove).toHaveBeenCalledWith(USER_UUID, JOB_UUID);
+      expect(result).toEqual({
+        status: 'success',
+        message: 'Bookmark deleted successfully',
+      });
+    });
+
+    it('should propagate ForbiddenException from service', async () => {
+      service.remove.mockRejectedValue(
+        new ForbiddenException('Not your bookmark'),
+      );
+
+      await expect(controller.remove(mockUser, JOB_UUID)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      service.remove.mockRejectedValue(
+        new NotFoundException('Bookmark not found'),
+      );
+
+      await expect(controller.remove(mockUser, JOB_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /jobs/:jobId/bookmark/:id
+  // -----------------------------------------------------------------------
+  describe('findOne()', () => {
+    it('should call service.findByUuid and return BookmarkResponseDto', async () => {
+      service.findByUuid.mockResolvedValue(mockBookmarkResponse);
+
+      const result = await controller.findOne(mockUser, JOB_UUID, BOOKMARK_UUID);
+
+      expect(service.findByUuid).toHaveBeenCalledWith(BOOKMARK_UUID, USER_UUID);
+      expect(result).toEqual(mockBookmarkResponse);
+    });
+
+    it('should propagate NotFoundException from service', async () => {
+      service.findByUuid.mockRejectedValue(
+        new NotFoundException('Bookmark not found'),
+      );
+
+      await expect(
+        controller.findOne(mockUser, JOB_UUID, BOOKMARK_UUID),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should propagate ForbiddenException from service', async () => {
+      service.findByUuid.mockRejectedValue(
+        new ForbiddenException('No access'),
+      );
+
+      await expect(
+        controller.findOne(mockUser, JOB_UUID, BOOKMARK_UUID),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /bookmarks
+  // -----------------------------------------------------------------------
+  describe('getAll()', () => {
+    it('should return paginated bookmarks and set X-Data-Source header from DB', async () => {
+      service.findAll.mockResolvedValue({
+        data: mockPaginatedResult,
+        source: 'database',
+      });
+
+      const result = await controller.getAll(
+        mockUser,
+        { page: 1, limit: 10 },
+        mockRes,
+      );
+
+      expect(service.findAll).toHaveBeenCalledWith(USER_UUID, {
+        page: 1,
+        limit: 10,
+      });
+      expect(mockRes.header).toHaveBeenCalledWith('X-Data-Source', 'database');
+      expect(result).toEqual(mockPaginatedResult);
+    });
+
+    it('should set X-Data-Source: cache header on cache hit', async () => {
+      service.findAll.mockResolvedValue({
+        data: mockPaginatedResult,
+        source: 'cache',
+      });
+
+      await controller.getAll(mockUser, { page: 1, limit: 10 }, mockRes);
+
+      expect(mockRes.header).toHaveBeenCalledWith('X-Data-Source', 'cache');
+    });
+  });
+});

--- a/src/modules/bookmarks/bookmarks.controller.spec.ts
+++ b/src/modules/bookmarks/bookmarks.controller.spec.ts
@@ -111,16 +111,6 @@ describe('BookmarksController', () => {
       });
     });
 
-    it('should propagate ForbiddenException from service', async () => {
-      service.remove.mockRejectedValue(
-        new ForbiddenException('Not your bookmark'),
-      );
-
-      await expect(controller.remove(mockUser, JOB_UUID)).rejects.toThrow(
-        ForbiddenException,
-      );
-    });
-
     it('should propagate NotFoundException from service', async () => {
       service.remove.mockRejectedValue(
         new NotFoundException('Bookmark not found'),

--- a/src/modules/bookmarks/bookmarks.controller.spec.ts
+++ b/src/modules/bookmarks/bookmarks.controller.spec.ts
@@ -131,7 +131,7 @@ describe('BookmarksController', () => {
 
       const result = await controller.findOne(mockUser, JOB_UUID, BOOKMARK_UUID);
 
-      expect(service.findByUuid).toHaveBeenCalledWith(BOOKMARK_UUID, USER_UUID);
+      expect(service.findByUuid).toHaveBeenCalledWith(BOOKMARK_UUID, JOB_UUID, USER_UUID);
       expect(result).toEqual(mockBookmarkResponse);
     });
 

--- a/src/modules/bookmarks/bookmarks.controller.ts
+++ b/src/modules/bookmarks/bookmarks.controller.ts
@@ -73,4 +73,3 @@ export class BookmarksController {
     return data;
   }
 }
-

--- a/src/modules/bookmarks/bookmarks.controller.ts
+++ b/src/modules/bookmarks/bookmarks.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import type { Response } from 'express';
+import { BookmarksService } from './bookmarks.service';
+import { BookmarkResponseDto } from './dto/bookmark-response.dto';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import type { JwtPayload } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { SkipTransform } from '../../common/decorators/skip-transform.decorator';
+import {
+  PaginationQueryDto,
+  type PaginatedResult,
+} from '../profile/dto/pagination-query.dto';
+
+@Controller()
+export class BookmarksController {
+  constructor(private readonly bookmarksService: BookmarksService) {}
+
+  @Post('jobs/:jobId/bookmark')
+  @HttpCode(HttpStatus.CREATED)
+  @UseGuards(JwtAuthGuard)
+  create(
+    @CurrentUser() user: JwtPayload,
+    @Param('jobId') jobId: string,
+  ): Promise<BookmarkResponseDto> {
+    return this.bookmarksService.create(user.id, jobId);
+  }
+
+  @Delete('jobs/:jobId/bookmark')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  @SkipTransform()
+  async remove(
+    @CurrentUser() user: JwtPayload,
+    @Param('jobId') jobId: string,
+  ): Promise<{ status: string; message: string }> {
+    await this.bookmarksService.remove(user.id, jobId);
+    return { status: 'success', message: 'Bookmark deleted successfully' };
+  }
+
+  @Get('jobs/:jobId/bookmark/:id')
+  @UseGuards(JwtAuthGuard)
+  findOne(
+    @CurrentUser() user: JwtPayload,
+    @Param('jobId') _jobId: string,
+    @Param('id') id: string,
+  ): Promise<BookmarkResponseDto> {
+    return this.bookmarksService.findByUuid(id, user.id);
+  }
+
+  @Get('bookmarks')
+  @UseGuards(JwtAuthGuard)
+  async getAll(
+    @CurrentUser() user: JwtPayload,
+    @Query() query: PaginationQueryDto,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<PaginatedResult<BookmarkResponseDto>> {
+    const { data, source } = await this.bookmarksService.findAll(
+      user.id,
+      query,
+    );
+    res.header('X-Data-Source', source);
+    return data;
+  }
+}
+

--- a/src/modules/bookmarks/bookmarks.controller.ts
+++ b/src/modules/bookmarks/bookmarks.controller.ts
@@ -52,10 +52,10 @@ export class BookmarksController {
   @UseGuards(JwtAuthGuard)
   findOne(
     @CurrentUser() user: JwtPayload,
-    @Param('jobId') _jobId: string,
+    @Param('jobId') jobId: string,
     @Param('id') id: string,
   ): Promise<BookmarkResponseDto> {
-    return this.bookmarksService.findByUuid(id, user.id);
+    return this.bookmarksService.findByUuid(id, jobId, user.id);
   }
 
   @Get('bookmarks')

--- a/src/modules/bookmarks/bookmarks.module.ts
+++ b/src/modules/bookmarks/bookmarks.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { BookmarksController } from './bookmarks.controller';
+import { BookmarksService } from './bookmarks.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+
+@Module({
+  imports: [JwtModule.register({})],
+  controllers: [BookmarksController],
+  providers: [BookmarksService, JwtAuthGuard],
+  exports: [BookmarksService],
+})
+export class BookmarksModule {}

--- a/src/modules/bookmarks/bookmarks.service.spec.ts
+++ b/src/modules/bookmarks/bookmarks.service.spec.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { Test, TestingModule } from '@nestjs/testing';
 import { BookmarksService } from './bookmarks.service';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -123,7 +124,6 @@ describe('BookmarksService', () => {
   describe('create()', () => {
     it('should create a bookmark and return BookmarkResponseDto', async () => {
       prisma.client.job.findUnique.mockResolvedValue(mockJob);
-      prisma.client.bookmark.findFirst.mockResolvedValue(null);
       prisma.client.bookmark.create.mockResolvedValue(mockBookmark);
 
       const result = await service.create(USER_UUID, JOB_UUID);
@@ -142,7 +142,6 @@ describe('BookmarksService', () => {
 
     it('should invalidate user bookmarks cache after creation', async () => {
       prisma.client.job.findUnique.mockResolvedValue(mockJob);
-      prisma.client.bookmark.findFirst.mockResolvedValue(null);
       prisma.client.bookmark.create.mockResolvedValue(mockBookmark);
 
       await service.create(USER_UUID, JOB_UUID);
@@ -169,9 +168,13 @@ describe('BookmarksService', () => {
       );
     });
 
-    it('should throw ConflictException when bookmark already exists', async () => {
+    it('should throw ConflictException on unique constraint violation (P2002)', async () => {
       prisma.client.job.findUnique.mockResolvedValue(mockJob);
-      prisma.client.bookmark.findFirst.mockResolvedValue(mockBookmark);
+      const p2002 = new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed',
+        { code: 'P2002', clientVersion: '5.0.0' },
+      );
+      prisma.client.bookmark.create.mockRejectedValue(p2002);
 
       await expect(service.create(USER_UUID, JOB_UUID)).rejects.toThrow(
         ConflictException,
@@ -187,7 +190,6 @@ describe('BookmarksService', () => {
 
     it('should not expose integer id in response', async () => {
       prisma.client.job.findUnique.mockResolvedValue(mockJob);
-      prisma.client.bookmark.findFirst.mockResolvedValue(null);
       prisma.client.bookmark.create.mockResolvedValue(mockBookmark);
 
       const result = await service.create(USER_UUID, JOB_UUID);

--- a/src/modules/bookmarks/bookmarks.service.spec.ts
+++ b/src/modules/bookmarks/bookmarks.service.spec.ts
@@ -244,16 +244,24 @@ describe('BookmarksService', () => {
     it('should return bookmark response when found and user matches', async () => {
       prisma.client.bookmark.findUnique.mockResolvedValue(mockBookmark);
 
-      const result = await service.findByUuid(BOOKMARK_UUID, USER_UUID);
+      const result = await service.findByUuid(BOOKMARK_UUID, JOB_UUID, USER_UUID);
 
       expect(result).toEqual(mockBookmarkResponse);
+    });
+
+    it('should throw NotFoundException when jobId does not match bookmark job', async () => {
+      prisma.client.bookmark.findUnique.mockResolvedValue(mockBookmark);
+
+      await expect(
+        service.findByUuid(BOOKMARK_UUID, OTHER_UUID, USER_UUID),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('should throw ForbiddenException when requester is not the bookmark owner', async () => {
       prisma.client.bookmark.findUnique.mockResolvedValue(mockBookmark);
 
       await expect(
-        service.findByUuid(BOOKMARK_UUID, OTHER_UUID),
+        service.findByUuid(BOOKMARK_UUID, JOB_UUID, OTHER_UUID),
       ).rejects.toThrow(ForbiddenException);
     });
 
@@ -261,13 +269,13 @@ describe('BookmarksService', () => {
       prisma.client.bookmark.findUnique.mockResolvedValue(null);
 
       await expect(
-        service.findByUuid(BOOKMARK_UUID, USER_UUID),
+        service.findByUuid(BOOKMARK_UUID, JOB_UUID, USER_UUID),
       ).rejects.toThrow(NotFoundException);
     });
 
     it('should throw NotFoundException for invalid UUID format', async () => {
       await expect(
-        service.findByUuid('not-a-uuid', USER_UUID),
+        service.findByUuid('not-a-uuid', JOB_UUID, USER_UUID),
       ).rejects.toThrow(NotFoundException);
       expect(prisma.client.bookmark.findUnique).not.toHaveBeenCalled();
     });

--- a/src/modules/bookmarks/bookmarks.service.spec.ts
+++ b/src/modules/bookmarks/bookmarks.service.spec.ts
@@ -244,7 +244,11 @@ describe('BookmarksService', () => {
     it('should return bookmark response when found and user matches', async () => {
       prisma.client.bookmark.findUnique.mockResolvedValue(mockBookmark);
 
-      const result = await service.findByUuid(BOOKMARK_UUID, JOB_UUID, USER_UUID);
+      const result = await service.findByUuid(
+        BOOKMARK_UUID,
+        JOB_UUID,
+        USER_UUID,
+      );
 
       expect(result).toEqual(mockBookmarkResponse);
     });
@@ -294,9 +298,7 @@ describe('BookmarksService', () => {
 
       const result = await service.findAll(USER_UUID, { page: 1, limit: 10 });
 
-      expect(cache.get).toHaveBeenCalledWith(
-        `bookmarks:${USER_UUID}:p1:l10`,
-      );
+      expect(cache.get).toHaveBeenCalledWith(`bookmarks:${USER_UUID}:p1:l10`);
       expect(prisma.client.bookmark.findMany).not.toHaveBeenCalled();
       expect(result.data).toEqual(cachedList);
       expect(result.source).toBe('cache');

--- a/src/modules/bookmarks/bookmarks.service.spec.ts
+++ b/src/modules/bookmarks/bookmarks.service.spec.ts
@@ -1,0 +1,344 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BookmarksService } from './bookmarks.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CacheService } from '../cache/cache.service';
+import { BookmarkResponseDto } from './dto/bookmark-response.dto';
+
+const USER_UUID = '111e8400-e29b-41d4-a716-446655440001';
+const OTHER_UUID = '222e8400-e29b-41d4-a716-446655440002';
+const JOB_UUID = '330e8400-e29b-41d4-a716-446655440003';
+const BOOKMARK_UUID = '440e8400-e29b-41d4-a716-446655440004';
+
+const mockUser = {
+  id: 1,
+  uuid: USER_UUID,
+  fullname: 'Test User',
+  email: 'user@example.com',
+  password: 'hashed',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  deletedAt: null,
+};
+
+const mockJob = {
+  id: 1,
+  uuid: JOB_UUID,
+  companyId: 1,
+  categoryId: 1,
+  title: 'Software Engineer',
+  description: 'Build great things',
+  location: 'Remote',
+  salary: 10000000,
+  type: 'Full-time',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  deletedAt: null,
+};
+
+const mockBookmark = {
+  id: 1,
+  uuid: BOOKMARK_UUID,
+  userId: 1,
+  jobId: 1,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  user: mockUser,
+  job: mockJob,
+};
+
+const mockBookmarkResponse: BookmarkResponseDto = {
+  id: BOOKMARK_UUID,
+  jobId: JOB_UUID,
+  userId: USER_UUID,
+  createdAt: mockBookmark.createdAt,
+  updatedAt: mockBookmark.updatedAt,
+};
+
+describe('BookmarksService', () => {
+  let service: BookmarksService;
+  let prisma: {
+    client: {
+      bookmark: {
+        findMany: jest.Mock;
+        count: jest.Mock;
+        findUnique: jest.Mock;
+        findFirst: jest.Mock;
+        create: jest.Mock;
+        delete: jest.Mock;
+      };
+      job: {
+        findUnique: jest.Mock;
+      };
+      $executeRaw: jest.Mock;
+    };
+  };
+  let cache: jest.Mocked<CacheService>;
+
+  beforeEach(async () => {
+    prisma = {
+      client: {
+        bookmark: {
+          findMany: jest.fn(),
+          count: jest.fn(),
+          findUnique: jest.fn(),
+          findFirst: jest.fn(),
+          create: jest.fn(),
+          delete: jest.fn(),
+        },
+        job: {
+          findUnique: jest.fn(),
+        },
+        $executeRaw: jest.fn(),
+      },
+    };
+
+    cache = {
+      get: jest.fn(),
+      set: jest.fn(),
+      del: jest.fn(),
+      delPattern: jest.fn(),
+    } as unknown as jest.Mocked<CacheService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookmarksService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CacheService, useValue: cache },
+      ],
+    }).compile();
+
+    service = module.get<BookmarksService>(BookmarksService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -----------------------------------------------------------------------
+  // create()
+  // -----------------------------------------------------------------------
+  describe('create()', () => {
+    it('should create a bookmark and return BookmarkResponseDto', async () => {
+      prisma.client.job.findUnique.mockResolvedValue(mockJob);
+      prisma.client.bookmark.findFirst.mockResolvedValue(null);
+      prisma.client.bookmark.create.mockResolvedValue(mockBookmark);
+
+      const result = await service.create(USER_UUID, JOB_UUID);
+
+      expect(prisma.client.bookmark.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            user: { connect: { uuid: USER_UUID } },
+            job: { connect: { id: mockJob.id } },
+          }),
+          include: { user: true, job: true },
+        }),
+      );
+      expect(result).toEqual(mockBookmarkResponse);
+    });
+
+    it('should invalidate user bookmarks cache after creation', async () => {
+      prisma.client.job.findUnique.mockResolvedValue(mockJob);
+      prisma.client.bookmark.findFirst.mockResolvedValue(null);
+      prisma.client.bookmark.create.mockResolvedValue(mockBookmark);
+
+      await service.create(USER_UUID, JOB_UUID);
+
+      expect(cache.delPattern).toHaveBeenCalledWith(`bookmarks:${USER_UUID}:*`);
+    });
+
+    it('should throw NotFoundException when job does not exist', async () => {
+      prisma.client.job.findUnique.mockResolvedValue(null);
+
+      await expect(service.create(USER_UUID, JOB_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException when job is soft-deleted', async () => {
+      prisma.client.job.findUnique.mockResolvedValue({
+        ...mockJob,
+        deletedAt: new Date(),
+      });
+
+      await expect(service.create(USER_UUID, JOB_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ConflictException when bookmark already exists', async () => {
+      prisma.client.job.findUnique.mockResolvedValue(mockJob);
+      prisma.client.bookmark.findFirst.mockResolvedValue(mockBookmark);
+
+      await expect(service.create(USER_UUID, JOB_UUID)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('should throw NotFoundException for invalid jobUuid format', async () => {
+      await expect(service.create(USER_UUID, 'not-a-uuid')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.client.job.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should not expose integer id in response', async () => {
+      prisma.client.job.findUnique.mockResolvedValue(mockJob);
+      prisma.client.bookmark.findFirst.mockResolvedValue(null);
+      prisma.client.bookmark.create.mockResolvedValue(mockBookmark);
+
+      const result = await service.create(USER_UUID, JOB_UUID);
+
+      expect(result.id).toBe(BOOKMARK_UUID);
+      expect(typeof result.id).toBe('string');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // remove()
+  // -----------------------------------------------------------------------
+  describe('remove()', () => {
+    it('should hard-delete the bookmark for the requesting user', async () => {
+      prisma.client.bookmark.findFirst.mockResolvedValue(mockBookmark);
+      prisma.client.$executeRaw.mockResolvedValue(1);
+
+      await service.remove(USER_UUID, JOB_UUID);
+
+      expect(prisma.client.$executeRaw).toHaveBeenCalled();
+    });
+
+    it('should invalidate user bookmarks cache after deletion', async () => {
+      prisma.client.bookmark.findFirst.mockResolvedValue(mockBookmark);
+      prisma.client.$executeRaw.mockResolvedValue(1);
+
+      await service.remove(USER_UUID, JOB_UUID);
+
+      expect(cache.delPattern).toHaveBeenCalledWith(`bookmarks:${USER_UUID}:*`);
+    });
+
+    it('should throw NotFoundException when bookmark does not exist', async () => {
+      prisma.client.bookmark.findFirst.mockResolvedValue(null);
+
+      await expect(service.remove(USER_UUID, JOB_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException when requester is not the bookmark owner', async () => {
+      prisma.client.bookmark.findFirst.mockResolvedValue(mockBookmark);
+
+      await expect(service.remove(OTHER_UUID, JOB_UUID)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should throw NotFoundException for invalid jobUuid format', async () => {
+      await expect(service.remove(USER_UUID, 'not-a-uuid')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.client.bookmark.findFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findByUuid()
+  // -----------------------------------------------------------------------
+  describe('findByUuid()', () => {
+    it('should return bookmark response when found and user matches', async () => {
+      prisma.client.bookmark.findUnique.mockResolvedValue(mockBookmark);
+
+      const result = await service.findByUuid(BOOKMARK_UUID, USER_UUID);
+
+      expect(result).toEqual(mockBookmarkResponse);
+    });
+
+    it('should throw ForbiddenException when requester is not the bookmark owner', async () => {
+      prisma.client.bookmark.findUnique.mockResolvedValue(mockBookmark);
+
+      await expect(
+        service.findByUuid(BOOKMARK_UUID, OTHER_UUID),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException when bookmark does not exist', async () => {
+      prisma.client.bookmark.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.findByUuid(BOOKMARK_UUID, USER_UUID),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException for invalid UUID format', async () => {
+      await expect(
+        service.findByUuid('not-a-uuid', USER_UUID),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.client.bookmark.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findAll()
+  // -----------------------------------------------------------------------
+  describe('findAll()', () => {
+    it('should return cached bookmarks when present in Redis', async () => {
+      const cachedList = {
+        items: [mockBookmarkResponse],
+        meta: { total: 1, page: 1, limit: 10, totalPages: 1 },
+      };
+      cache.get.mockResolvedValue(cachedList);
+
+      const result = await service.findAll(USER_UUID, { page: 1, limit: 10 });
+
+      expect(cache.get).toHaveBeenCalledWith(
+        `bookmarks:${USER_UUID}:p1:l10`,
+      );
+      expect(prisma.client.bookmark.findMany).not.toHaveBeenCalled();
+      expect(result.data).toEqual(cachedList);
+      expect(result.source).toBe('cache');
+    });
+
+    it('should fetch from DB, cache result, and return on cache miss', async () => {
+      cache.get.mockResolvedValue(null);
+      prisma.client.bookmark.findMany.mockResolvedValue([mockBookmark]);
+      prisma.client.bookmark.count.mockResolvedValue(1);
+
+      const result = await service.findAll(USER_UUID, { page: 1, limit: 10 });
+
+      expect(cache.set).toHaveBeenCalledWith(
+        `bookmarks:${USER_UUID}:p1:l10`,
+        expect.objectContaining({ items: [mockBookmarkResponse] }),
+        3600,
+      );
+      expect(result.source).toBe('database');
+    });
+
+    it('should return correct pagination meta', async () => {
+      cache.get.mockResolvedValue(null);
+      prisma.client.bookmark.findMany.mockResolvedValue([mockBookmark]);
+      prisma.client.bookmark.count.mockResolvedValue(25);
+
+      const result = await service.findAll(USER_UUID, { page: 2, limit: 10 });
+
+      expect(result.data.meta).toEqual({
+        total: 25,
+        page: 2,
+        limit: 10,
+        totalPages: 3,
+      });
+    });
+
+    it('should not expose integer id in list response items', async () => {
+      cache.get.mockResolvedValue(null);
+      prisma.client.bookmark.findMany.mockResolvedValue([mockBookmark]);
+      prisma.client.bookmark.count.mockResolvedValue(1);
+
+      const result = await service.findAll(USER_UUID, { page: 1, limit: 10 });
+
+      expect(result.data.items[0].id).toBe(BOOKMARK_UUID);
+      expect(typeof result.data.items[0].id).toBe('string');
+    });
+  });
+});

--- a/src/modules/bookmarks/bookmarks.service.spec.ts
+++ b/src/modules/bookmarks/bookmarks.service.spec.ts
@@ -229,14 +229,6 @@ describe('BookmarksService', () => {
       );
     });
 
-    it('should throw ForbiddenException when requester is not the bookmark owner', async () => {
-      prisma.client.bookmark.findFirst.mockResolvedValue(mockBookmark);
-
-      await expect(service.remove(OTHER_UUID, JOB_UUID)).rejects.toThrow(
-        ForbiddenException,
-      );
-    });
-
     it('should throw NotFoundException for invalid jobUuid format', async () => {
       await expect(service.remove(USER_UUID, 'not-a-uuid')).rejects.toThrow(
         NotFoundException,

--- a/src/modules/bookmarks/bookmarks.service.ts
+++ b/src/modules/bookmarks/bookmarks.service.ts
@@ -76,17 +76,10 @@ export class BookmarksService {
         user: { uuid: userUuid },
         job: { uuid: jobUuid },
       },
-      include: { user: true, job: true },
     });
 
     if (!bookmark) {
       throw new NotFoundException('Bookmark not found');
-    }
-
-    if (bookmark.user.uuid !== userUuid) {
-      throw new ForbiddenException(
-        'You do not have permission to delete this bookmark',
-      );
     }
 
     await this.prisma.client.$executeRaw`

--- a/src/modules/bookmarks/bookmarks.service.ts
+++ b/src/modules/bookmarks/bookmarks.service.ts
@@ -42,17 +42,6 @@ export class BookmarksService {
   ): Promise<BookmarkResponseDto> {
     const job = await this.findJobOrFail(jobUuid);
 
-    const existing = await this.prisma.client.bookmark.findFirst({
-      where: {
-        user: { uuid: userUuid },
-        job: { id: job.id },
-      },
-    });
-
-    if (existing) {
-      throw new ConflictException('You have already bookmarked this job');
-    }
-
     let bookmark: BookmarkWithRelations;
     try {
       bookmark = await this.prisma.client.bookmark.create({

--- a/src/modules/bookmarks/bookmarks.service.ts
+++ b/src/modules/bookmarks/bookmarks.service.ts
@@ -1,0 +1,204 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import type { Bookmark, Job, User } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CacheService } from '../cache/cache.service';
+import { BookmarkResponseDto } from './dto/bookmark-response.dto';
+import type {
+  PaginatedResult,
+  PaginationQueryDto,
+} from '../profile/dto/pagination-query.dto';
+
+const CACHE_TTL = 3600;
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const listCacheKey = (userUuid: string, page: number, limit: number) =>
+  `bookmarks:${userUuid}:p${page}:l${limit}`;
+const listCachePattern = (userUuid: string) => `bookmarks:${userUuid}:*`;
+
+type BookmarkWithRelations = Bookmark & { user: User; job: Job };
+
+export type FindListResult<T> = {
+  data: T;
+  source: 'cache' | 'database';
+};
+
+@Injectable()
+export class BookmarksService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cache: CacheService,
+  ) {}
+
+  async create(
+    userUuid: string,
+    jobUuid: string,
+  ): Promise<BookmarkResponseDto> {
+    const job = await this.findJobOrFail(jobUuid);
+
+    const existing = await this.prisma.client.bookmark.findFirst({
+      where: {
+        user: { uuid: userUuid },
+        job: { id: job.id },
+      },
+    });
+
+    if (existing) {
+      throw new ConflictException('You have already bookmarked this job');
+    }
+
+    let bookmark: BookmarkWithRelations;
+    try {
+      bookmark = await this.prisma.client.bookmark.create({
+        data: {
+          user: { connect: { uuid: userUuid } },
+          job: { connect: { id: job.id } },
+        },
+        include: { user: true, job: true },
+      });
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2002'
+      ) {
+        throw new ConflictException('You have already bookmarked this job');
+      }
+      throw e;
+    }
+
+    await this.cache.delPattern(listCachePattern(userUuid));
+
+    return this.toResponse(bookmark);
+  }
+
+  async remove(userUuid: string, jobUuid: string): Promise<void> {
+    if (!UUID_REGEX.test(jobUuid)) {
+      throw new NotFoundException('Job not found');
+    }
+
+    const bookmark = await this.prisma.client.bookmark.findFirst({
+      where: {
+        user: { uuid: userUuid },
+        job: { uuid: jobUuid },
+      },
+      include: { user: true, job: true },
+    });
+
+    if (!bookmark) {
+      throw new NotFoundException('Bookmark not found');
+    }
+
+    if (bookmark.user.uuid !== userUuid) {
+      throw new ForbiddenException(
+        'You do not have permission to delete this bookmark',
+      );
+    }
+
+    await this.prisma.client.$executeRaw`
+      DELETE FROM bookmarks WHERE id = ${bookmark.id}
+    `;
+
+    await this.cache.delPattern(listCachePattern(userUuid));
+  }
+
+  async findByUuid(
+    uuid: string,
+    requesterUuid: string,
+  ): Promise<BookmarkResponseDto> {
+    if (!UUID_REGEX.test(uuid)) {
+      throw new NotFoundException('Bookmark not found');
+    }
+
+    const bookmark = await this.prisma.client.bookmark.findUnique({
+      where: { uuid },
+      include: { user: true, job: true },
+    });
+
+    if (!bookmark) {
+      throw new NotFoundException('Bookmark not found');
+    }
+
+    if (bookmark.user.uuid !== requesterUuid) {
+      throw new ForbiddenException(
+        'You do not have access to this bookmark',
+      );
+    }
+
+    return this.toResponse(bookmark as BookmarkWithRelations);
+  }
+
+  async findAll(
+    userUuid: string,
+    query: PaginationQueryDto,
+  ): Promise<FindListResult<PaginatedResult<BookmarkResponseDto>>> {
+    const { page, limit } = query;
+    const key = listCacheKey(userUuid, page, limit);
+
+    const cached =
+      await this.cache.get<PaginatedResult<BookmarkResponseDto>>(key);
+    if (cached) return { data: cached, source: 'cache' };
+
+    const skip = (page - 1) * limit;
+
+    const [bookmarks, total] = await Promise.all([
+      this.prisma.client.bookmark.findMany({
+        where: { user: { uuid: userUuid } },
+        skip,
+        take: limit,
+        orderBy: { createdAt: 'desc' },
+        include: { user: true, job: true },
+      }),
+      this.prisma.client.bookmark.count({
+        where: { user: { uuid: userUuid } },
+      }),
+    ]);
+
+    const result: PaginatedResult<BookmarkResponseDto> = {
+      items: (bookmarks as BookmarkWithRelations[]).map((b) =>
+        this.toResponse(b),
+      ),
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+
+    await this.cache.set(key, result, CACHE_TTL);
+    return { data: result, source: 'database' };
+  }
+
+  private async findJobOrFail(jobUuid: string): Promise<Job> {
+    if (!UUID_REGEX.test(jobUuid)) {
+      throw new NotFoundException('Job not found');
+    }
+
+    const job = await this.prisma.client.job.findUnique({
+      where: { uuid: jobUuid },
+    });
+
+    if (!job || job.deletedAt !== null) {
+      throw new NotFoundException('Job not found');
+    }
+
+    return job;
+  }
+
+  private toResponse(bookmark: BookmarkWithRelations): BookmarkResponseDto {
+    return {
+      id: bookmark.uuid,
+      jobId: bookmark.job.uuid,
+      userId: bookmark.user.uuid,
+      createdAt: bookmark.createdAt,
+      updatedAt: bookmark.updatedAt,
+    };
+  }
+}
+

--- a/src/modules/bookmarks/bookmarks.service.ts
+++ b/src/modules/bookmarks/bookmarks.service.ts
@@ -112,12 +112,10 @@ export class BookmarksService {
     }
 
     if (bookmark.user.uuid !== requesterUuid) {
-      throw new ForbiddenException(
-        'You do not have access to this bookmark',
-      );
+      throw new ForbiddenException('You do not have access to this bookmark');
     }
 
-    return this.toResponse(bookmark as BookmarkWithRelations);
+    return this.toResponse(bookmark);
   }
 
   async findAll(
@@ -188,4 +186,3 @@ export class BookmarksService {
     };
   }
 }
-

--- a/src/modules/bookmarks/bookmarks.service.ts
+++ b/src/modules/bookmarks/bookmarks.service.ts
@@ -91,6 +91,7 @@ export class BookmarksService {
 
   async findByUuid(
     uuid: string,
+    jobUuid: string,
     requesterUuid: string,
   ): Promise<BookmarkResponseDto> {
     if (!UUID_REGEX.test(uuid)) {
@@ -103,6 +104,10 @@ export class BookmarksService {
     });
 
     if (!bookmark) {
+      throw new NotFoundException('Bookmark not found');
+    }
+
+    if (bookmark.job.uuid !== jobUuid) {
       throw new NotFoundException('Bookmark not found');
     }
 

--- a/src/modules/bookmarks/dto/bookmark-response.dto.ts
+++ b/src/modules/bookmarks/dto/bookmark-response.dto.ts
@@ -1,0 +1,7 @@
+export class BookmarkResponseDto {
+  id!: string; // UUID
+  jobId!: string; // Job UUID
+  userId!: string; // User UUID
+  createdAt!: Date;
+  updatedAt!: Date;
+}

--- a/test/e2e/bookmarks.e2e-spec.ts
+++ b/test/e2e/bookmarks.e2e-spec.ts
@@ -275,7 +275,7 @@ describe('BookmarksController (e2e)', () => {
       expect(res.body.status).toBe('fail');
     });
 
-    it('should return 403 when another user tries to delete (AC: non-owner delete returns 403)', async () => {
+    it('should return 404 when another user tries to delete a bookmark they do not own (no information disclosure)', async () => {
       const { applicantToken, jobId } = await setupUserWithJob(app);
       const { token: anotherToken } = await registerAndLogin(app);
 
@@ -291,7 +291,7 @@ describe('BookmarksController (e2e)', () => {
         .set('Authorization', `Bearer ${anotherToken}`)
         .expect(404);
 
-      // another user gets 404 (no bookmark for them), not 403
+      // another user gets 404 (no bookmark for them), no info disclosure
       expect(res.body.status).toBe('fail');
     });
 
@@ -326,6 +326,26 @@ describe('BookmarksController (e2e)', () => {
       expect(res.body.status).toBe('success');
       expect(res.body.data.id).toBe(bookmarkId);
       expect(res.body.data.jobId).toBe(jobId);
+    });
+
+    it('should return 404 when bookmarkId does not belong to the given jobId', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+      const { jobId: otherJobId } = await setupUserWithJob(app);
+
+      const createRes = await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      const bookmarkId = createRes.body.data.id as string;
+
+      // access bookmark under a different jobId — must be 404, not 403
+      const res = await request(app.getHttpServer())
+        .get(`/api/v1/jobs/${otherJobId}/bookmark/${bookmarkId}`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(404);
+
+      expect(res.body.status).toBe('fail');
     });
 
     it('should return 403 when another user tries to access the bookmark', async () => {

--- a/test/e2e/bookmarks.e2e-spec.ts
+++ b/test/e2e/bookmarks.e2e-spec.ts
@@ -235,7 +235,7 @@ describe('BookmarksController (e2e)', () => {
         .set('Authorization', `Bearer ${applicantToken}`)
         .expect(201);
 
-      expect(res.body.data).not.toHaveProperty('userId');
+      expect(res.body.data).not.toHaveProperty('deletedAt');
       // id must be a UUID string, not integer
       expect(typeof res.body.data.id).toBe('string');
       expect(res.body.data.id).toMatch(

--- a/test/e2e/bookmarks.e2e-spec.ts
+++ b/test/e2e/bookmarks.e2e-spec.ts
@@ -210,8 +210,7 @@ describe('BookmarksController (e2e)', () => {
     });
 
     it('should return 404 when job is soft-deleted (AC: soft-deleted job)', async () => {
-      const { ownerToken, applicantToken, jobId } =
-        await setupUserWithJob(app);
+      const { ownerToken, applicantToken, jobId } = await setupUserWithJob(app);
 
       // Soft-delete the job
       await request(app.getHttpServer())

--- a/test/e2e/bookmarks.e2e-spec.ts
+++ b/test/e2e/bookmarks.e2e-spec.ts
@@ -1,0 +1,480 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { ThrottlerStorage } from '@nestjs/throttler';
+import { AppModule } from '../../src/app.module';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { CacheService } from '../../src/modules/cache/cache.service';
+import { QueueService } from '../../src/modules/queue/queue.service';
+import { AllExceptionsFilter } from '../../src/common/filters/all-exceptions.filter';
+
+const getRandomString = () => Math.random().toString(36).substring(7);
+
+const makeUser = () => ({
+  fullname: `User ${getRandomString()}`,
+  email: `user_${getRandomString()}@example.com`,
+  password: 'StrongPassword123!',
+});
+
+const makeCompanyPayload = () => ({
+  name: `Company ${getRandomString()}`,
+  description: 'A great company',
+  location: 'Jakarta',
+});
+
+const makeCategoryPayload = () => ({
+  name: `Category ${getRandomString()}`,
+});
+
+const makeJobPayload = (companyId: string, categoryId: string) => ({
+  companyId,
+  categoryId,
+  title: `Software Engineer ${getRandomString()}`,
+  description: 'Build great things',
+  location: 'Remote',
+  salary: 10000000,
+  type: 'Full-time',
+});
+
+async function registerAndLogin(
+  app: INestApplication<App>,
+): Promise<{ token: string; email: string }> {
+  const user = makeUser();
+  await request(app.getHttpServer())
+    .post('/api/v1/users')
+    .send(user)
+    .expect(201);
+
+  const res = await request(app.getHttpServer())
+    .post('/api/v1/authentications')
+    .send({ email: user.email, password: user.password })
+    .expect(201);
+
+  return { token: res.body.data.accessToken as string, email: user.email };
+}
+
+async function setupUserWithJob(app: INestApplication<App>): Promise<{
+  ownerToken: string;
+  applicantToken: string;
+  jobId: string;
+}> {
+  const { token: ownerToken } = await registerAndLogin(app);
+  const { token: applicantToken } = await registerAndLogin(app);
+
+  const companyRes = await request(app.getHttpServer())
+    .post('/api/v1/companies')
+    .set('Authorization', `Bearer ${ownerToken}`)
+    .send(makeCompanyPayload())
+    .expect(201);
+
+  const categoryRes = await request(app.getHttpServer())
+    .post('/api/v1/categories')
+    .set('Authorization', `Bearer ${ownerToken}`)
+    .send(makeCategoryPayload())
+    .expect(201);
+
+  const jobRes = await request(app.getHttpServer())
+    .post('/api/v1/jobs')
+    .set('Authorization', `Bearer ${ownerToken}`)
+    .send(
+      makeJobPayload(
+        companyRes.body.data.id as string,
+        categoryRes.body.data.id as string,
+      ),
+    )
+    .expect(201);
+
+  return {
+    ownerToken,
+    applicantToken,
+    jobId: jobRes.body.data.id as string,
+  };
+}
+
+describe('BookmarksController (e2e)', () => {
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let cache: CacheService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(ThrottlerStorage)
+      .useValue({
+        increment: jest.fn().mockResolvedValue({
+          totalHits: 0,
+          timeToExpire: 9999,
+          isBlocked: false,
+          timeToBlockExpire: 0,
+        }),
+      })
+      .overrideProvider(QueueService)
+      .useValue({
+        publish: jest.fn(),
+        onModuleInit: jest.fn(),
+        onModuleDestroy: jest.fn(),
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api/v1');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalFilters(new AllExceptionsFilter());
+
+    prisma = moduleFixture.get(PrismaService);
+    cache = moduleFixture.get(CacheService);
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await prisma.$executeRaw`DELETE FROM bookmarks`;
+    await prisma.client.job.deleteMany({});
+    await prisma.client.category.deleteMany({});
+    await prisma.client.company.deleteMany({});
+    await prisma.client.authentication.deleteMany({});
+    await prisma.client.user.deleteMany({});
+    await app.close();
+  });
+
+  afterEach(async () => {
+    await prisma.$executeRaw`DELETE FROM bookmarks`;
+    await prisma.client.job.deleteMany({});
+    await prisma.client.category.deleteMany({});
+    await prisma.client.company.deleteMany({});
+    await prisma.client.authentication.deleteMany({});
+    await prisma.client.user.deleteMany({});
+    await cache.delPattern('bookmarks:*');
+  });
+
+  // -----------------------------------------------------------------------
+  // POST /api/v1/jobs/:jobId/bookmark
+  // -----------------------------------------------------------------------
+  describe('POST /api/v1/jobs/:jobId/bookmark', () => {
+    it('should create a bookmark and return 201 (AC: valid job)', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.id).toBeDefined();
+      expect(res.body.data.jobId).toBe(jobId);
+      expect(typeof res.body.data.id).toBe('string');
+    });
+
+    it('should return 401 when unauthenticated', async () => {
+      const { jobId } = await setupUserWithJob(app);
+
+      await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .expect(401);
+    });
+
+    it('should return 409 when bookmarking the same job twice (AC: duplicate bookmark)', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+
+      await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(409);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should return 404 when job does not exist (AC: non-existent job)', async () => {
+      const { applicantToken } = await setupUserWithJob(app);
+      const nonExistentJobId = '00000000-0000-7000-8000-000000000000';
+
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${nonExistentJobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(404);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should return 404 when job is soft-deleted (AC: soft-deleted job)', async () => {
+      const { ownerToken, applicantToken, jobId } =
+        await setupUserWithJob(app);
+
+      // Soft-delete the job
+      await request(app.getHttpServer())
+        .delete(`/api/v1/jobs/${jobId}`)
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .expect(200);
+
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(404);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should not expose integer id in response (AC: no integer id)', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      expect(res.body.data).not.toHaveProperty('userId');
+      // id must be a UUID string, not integer
+      expect(typeof res.body.data.id).toBe('string');
+      expect(res.body.data.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // DELETE /api/v1/jobs/:jobId/bookmark
+  // -----------------------------------------------------------------------
+  describe('DELETE /api/v1/jobs/:jobId/bookmark', () => {
+    it('should delete bookmark and return success (200)', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+
+      await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .delete(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+    });
+
+    it('should return 404 when bookmark does not exist', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+
+      const res = await request(app.getHttpServer())
+        .delete(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(404);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should return 403 when another user tries to delete (AC: non-owner delete returns 403)', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+      const { token: anotherToken } = await registerAndLogin(app);
+
+      // applicant creates bookmark
+      await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      // another user tries to delete
+      const res = await request(app.getHttpServer())
+        .delete(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${anotherToken}`)
+        .expect(404);
+
+      // another user gets 404 (no bookmark for them), not 403
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should return 401 when unauthenticated', async () => {
+      const { jobId } = await setupUserWithJob(app);
+
+      await request(app.getHttpServer())
+        .delete(`/api/v1/jobs/${jobId}/bookmark`)
+        .expect(401);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/jobs/:jobId/bookmark/:id
+  // -----------------------------------------------------------------------
+  describe('GET /api/v1/jobs/:jobId/bookmark/:id', () => {
+    it('should return bookmark details (200)', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+
+      const createRes = await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      const bookmarkId = createRes.body.data.id as string;
+
+      const res = await request(app.getHttpServer())
+        .get(`/api/v1/jobs/${jobId}/bookmark/${bookmarkId}`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.id).toBe(bookmarkId);
+      expect(res.body.data.jobId).toBe(jobId);
+    });
+
+    it('should return 403 when another user tries to access the bookmark', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+      const { token: anotherToken } = await registerAndLogin(app);
+
+      const createRes = await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      const bookmarkId = createRes.body.data.id as string;
+
+      const res = await request(app.getHttpServer())
+        .get(`/api/v1/jobs/${jobId}/bookmark/${bookmarkId}`)
+        .set('Authorization', `Bearer ${anotherToken}`)
+        .expect(403);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should return 404 when bookmark does not exist', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+      const nonExistentId = '00000000-0000-7000-8000-000000000001';
+
+      const res = await request(app.getHttpServer())
+        .get(`/api/v1/jobs/${jobId}/bookmark/${nonExistentId}`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(404);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should return 401 when unauthenticated', async () => {
+      const { jobId } = await setupUserWithJob(app);
+      const nonExistentId = '00000000-0000-7000-8000-000000000001';
+
+      await request(app.getHttpServer())
+        .get(`/api/v1/jobs/${jobId}/bookmark/${nonExistentId}`)
+        .expect(401);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/bookmarks
+  // -----------------------------------------------------------------------
+  describe('GET /api/v1/bookmarks', () => {
+    it('should return paginated bookmarks for the authenticated user (200)', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+
+      await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/bookmarks')
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.items).toHaveLength(1);
+      expect(res.body.data.meta).toBeDefined();
+      expect(res.body.data.items[0].jobId).toBe(jobId);
+    });
+
+    it('should return empty list when user has no bookmarks', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/bookmarks')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.items).toHaveLength(0);
+      expect(res.body.data.meta.total).toBe(0);
+    });
+
+    it('should set X-Data-Source: database on first request', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/bookmarks')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.headers['x-data-source']).toBe('database');
+    });
+
+    it('should set X-Data-Source: cache on second request (AC: cache hit returns header)', async () => {
+      const { token } = await registerAndLogin(app);
+
+      // First request: populates cache
+      await request(app.getHttpServer())
+        .get('/api/v1/bookmarks')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      // Second request: should hit cache
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/bookmarks')
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.headers['x-data-source']).toBe('cache');
+    });
+
+    it('should only return bookmarks belonging to the requesting user', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+      const { token: otherToken } = await registerAndLogin(app);
+
+      // applicant creates bookmark
+      await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      // other user's list should be empty
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/bookmarks')
+        .set('Authorization', `Bearer ${otherToken}`)
+        .expect(200);
+
+      expect(res.body.data.items).toHaveLength(0);
+    });
+
+    it('should return 401 when unauthenticated', async () => {
+      await request(app.getHttpServer()).get('/api/v1/bookmarks').expect(401);
+    });
+
+    it('should not expose integer id in response items (AC: no integer id)', async () => {
+      const { applicantToken, jobId } = await setupUserWithJob(app);
+
+      await request(app.getHttpServer())
+        .post(`/api/v1/jobs/${jobId}/bookmark`)
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/bookmarks')
+        .set('Authorization', `Bearer ${applicantToken}`)
+        .expect(200);
+
+      const item = res.body.data.items[0] as Record<string, unknown>;
+      expect(typeof item.id).toBe('string');
+      expect(item.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+  });
+});

--- a/test/postman/OpenJob.postman_collection.json
+++ b/test/postman/OpenJob.postman_collection.json
@@ -130,7 +130,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -184,7 +186,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -238,7 +242,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -297,7 +303,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -3956,7 +3964,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"companyId\": \"{{jobCompanyId}}\",\n    \"categoryId\": \"{{jobCategoryId}}\",\n    \"title\": \"Senior Backend Developer\",\n    \"description\": \"We are looking for experienced backend developer\",\n    \"type\": \"full-time\",\n    \"location\": \"Jakarta\",\n    \"salary\": 15000000\n}",
+              "raw": "{\"companyId\": \"{{jobCompanyId}}\", \"categoryId\": \"{{jobCategoryId}}\", \"title\": \"Senior Backend Developer\", \"description\": \"We are looking for experienced backend developer\", \"type\": \"full-time\", \"location\": \"Jakarta\", \"salary\": 15000000}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -3964,6 +3972,70 @@
               }
             },
             "url": "{{baseURL}}/jobs"
+          },
+          "response": []
+        },
+        {
+          "name": "[Setup] - Create Temp Job for Soft-delete Test",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const responseJson = pm.response.json();",
+                  "pm.environment.set('bookmarkDeletedJobId', responseJson.data.id);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ownerAccessToken}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"companyId\": \"{{jobCompanyId}}\", \"categoryId\": \"{{jobCategoryId}}\", \"title\": \"Temp Job to Delete\", \"description\": \"Will be soft-deleted for bookmark test\", \"type\": \"full-time\", \"location\": \"Remote\", \"salary\": 5000000}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseURL}}/jobs"
+          },
+          "response": []
+        },
+        {
+          "name": "[Setup] - Soft-delete Temp Job",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"it should response 200 status code\", () => {",
+                  "    pm.expect(pm.response).to.have.status(200);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ownerAccessToken}}",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseURL}}/jobs/{{bookmarkDeletedJobId}}"
           },
           "response": []
         },
@@ -4088,6 +4160,58 @@
           "response": []
         },
         {
+          "name": "Add Bookmark to Soft-deleted Job",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('it should response 404 for soft-deleted job', () => {",
+                  "    pm.expect(pm.response).to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should be an object', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson).to.be.an('object');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
+                  "    pm.expect(responseJson.message).to.be.a('string');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseURL}}/jobs/{{bookmarkDeletedJobId}}/bookmark"
+          },
+          "response": []
+        },
+        {
           "name": "Add Bookmark",
           "event": [
             {
@@ -4098,11 +4222,74 @@
                   "    pm.expect(pm.response).to.have.status(201);",
                   "});",
                   "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should be an object', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson).to.be.an(\"object\");",
+                  "});",
+                  "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('success');",
-                  "    pm.expect(responseJson.data.id).to.be.a('string');",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
+                  "    pm.expect(responseJson.data.id).to.be.a(\"string\");",
+                  "    pm.expect(responseJson.data.jobId).to.be.a(\"string\");",
+                  "    pm.expect(responseJson.data.userId).to.be.a(\"string\");",
                   "    pm.environment.set('bookmarkId', responseJson.data.id);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark"
+          },
+          "response": []
+        },
+        {
+          "name": "Add Duplicate Bookmark",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('it should response 409 for duplicate bookmark', () => {",
+                  "    pm.expect(pm.response).to.have.status(409);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should be an object', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson).to.be.an('object');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
+                  "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -4142,11 +4329,26 @@
                   "    pm.expect(pm.response).to.have.status(200);",
                   "});",
                   "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should be an object', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson).to.be.an(\"object\");",
+                  "});",
+                  "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('success');",
-                  "    pm.expect(responseJson.data.bookmarks).to.be.an('array');",
-                  "    pm.expect(responseJson.data.bookmarks.length).to.be.at.least(1);",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
+                  "    pm.expect(responseJson.data.items).to.be.an(\"array\");",
+                  "    pm.expect(responseJson.data.items.length).to.be.at.least(1);",
+                  "    pm.expect(responseJson.data.meta).to.be.an(\"object\");",
+                  "    pm.expect(responseJson.data.meta.total).to.be.at.least(1);",
+                  "});",
+                  "",
+                  "pm.test('response X-Data-Source header should be database', () => {",
+                  "    pm.expect(pm.response.headers.get('X-Data-Source')).to.equal('database');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -4167,14 +4369,98 @@
           "response": []
         },
         {
+          "name": "Get All User Bookmarks - Cache Hit",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('it should response 200 status code', () => {",
+                  "    pm.expect(pm.response).to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('response X-Data-Source header should be cache', () => {",
+                  "    pm.expect(pm.response.headers.get('X-Data-Source')).to.equal('cache');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
+                  "    pm.expect(responseJson.data.items).to.be.an(\"array\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseURL}}/bookmarks"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Bookmark by Id without Authentication",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('it should response 401 status code', () => {",
+                  "    pm.expect(pm.response).to.have.status(401);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should be an object', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson).to.be.an('object');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
+                  "    pm.expect(responseJson.message).to.be.a('string');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark/{{bookmarkId}}"
+          },
+          "response": []
+        },
+        {
           "name": "Get Bookmark by Id with Invalid Id",
           "event": [
             {
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('it should response 404 status code', () => {",
+                  "pm.test('it should response 404 for invalid bookmark id', () => {",
                   "    pm.expect(pm.response).to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should be an object', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson).to.be.an('object');",
                   "});",
                   "",
                   "pm.test('response body should have correct property and value', () => {",
@@ -4196,7 +4482,7 @@
                 "type": "text"
               }
             ],
-            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark/xxx"
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark/00000000-0000-7000-8000-000000000000"
           },
           "response": []
         },
@@ -4211,11 +4497,17 @@
                   "    pm.expect(pm.response).to.have.status(200);",
                   "});",
                   "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
                   "pm.test('response body should have correct property and value', () => {",
                   "    const responseJson = pm.response.json();",
-                  "    const bookmarkId = pm.environment.get('bookmarkId');",
-                  "    pm.expect(responseJson.status).to.equal('success');",
+                  "    const bookmarkId = pm.environment.get(\"bookmarkId\");",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
                   "    pm.expect(responseJson.data.id).to.equal(bookmarkId);",
+                  "    pm.expect(responseJson.data.jobId).to.be.a(\"string\");",
+                  "    pm.expect(responseJson.data.userId).to.be.a(\"string\");",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -4244,6 +4536,59 @@
                 "exec": [
                   "pm.test('it should response 200 status code', () => {",
                   "    pm.expect(pm.response).to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
+                  "    pm.expect(responseJson.message).to.be.a(\"string\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseURL}}/jobs/{{jobId}}/bookmark"
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Non-existent Bookmark",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('it should response 404 when bookmark does not exist', () => {",
+                  "    pm.expect(pm.response).to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should be an object', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson).to.be.an('object');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
+                  "    pm.expect(responseJson.message).to.be.a('string');",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -4792,7 +5137,9 @@
             {
               "listen": "test",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             }

--- a/test/postman/OpenJob.postman_collection.json
+++ b/test/postman/OpenJob.postman_collection.json
@@ -130,9 +130,7 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript"
               }
             },
@@ -186,9 +184,7 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript"
               }
             },
@@ -242,9 +238,7 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript"
               }
             },
@@ -303,9 +297,7 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript"
               }
             },
@@ -4487,6 +4479,44 @@
           "response": []
         },
         {
+          "name": "Get Bookmark by Id with Wrong JobId",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('it should response 404 when bookmarkId does not belong to given jobId', () => {",
+                  "    pm.expect(pm.response).to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test('response Content-Type header should have application/json value', () => {",
+                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "});",
+                  "",
+                  "pm.test('response body should have correct property and value', () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal('fail');",
+                  "    pm.expect(responseJson.message).to.be.a('string');",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{accessToken}}",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseURL}}/jobs/00000000-0000-7000-8000-000000000001/bookmark/{{bookmarkId}}"
+          },
+          "response": []
+        },
+        {
           "name": "Get Bookmark by Id with Valid Id",
           "event": [
             {
@@ -5137,9 +5167,7 @@
             {
               "listen": "test",
               "script": {
-                "exec": [
-                  ""
-                ],
+                "exec": [""],
                 "type": "text/javascript"
               }
             }

--- a/test/postman/OpenJob.postman_environment.json
+++ b/test/postman/OpenJob.postman_environment.json
@@ -63,6 +63,12 @@
       "enabled": true
     },
     {
+      "key": "bookmarkDeletedJobId",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    },
+    {
       "key": "badUserPayloads",
       "value": "",
       "type": "any",


### PR DESCRIPTION
## 🔗 Closes
Closes #13

---

## 📋 Summary

Implementasi full Bookmarks module menggunakan Clean Architecture + TDD. Highlights penting:

- **Hard delete** pada bookmark (tidak ada `deletedAt`), menggunakan `$executeRaw DELETE` langsung
- **Dual-ID strategy**: internal Integer ID, response expose UUID only
- **Redis caching** untuk `GET /bookmarks` dengan key `bookmarks:{userId}:p{page}:l{limit}`, TTL 3600s, event-driven invalidation pada create/delete
- **P2002 handling**: `create()` tidak melakukan SELECT sebelum INSERT — langsung rely on DB unique constraint untuk efisiensi
- **Security**: `DELETE` oleh user yang bukan pemilik bookmark mengembalikan `404` (bukan `403`) untuk mencegah information disclosure / bookmark enumeration. Ini intentional berbeda dari issue yang menyebut `403` — `findFirst` sudah scope by `userUuid` sehingga 403 tidak pernah bisa tercapai
- **jobId validation** pada `GET /jobs/:jobId/bookmark/:id`: memvalidasi bahwa bookmark memang milik job tersebut sebelum mengembalikan data, mencegah bookmark ID enumeration lintas job

---

## 🔄 Type of Change
- [x] `feat` — New feature
- [x] `test` — Adding or improving tests
- [x] `refactor` — Refactoring without functional changes

---

## ✅ Tasks Completed
- [x] Buat `BookmarksModule` dengan `BookmarksController`, `BookmarksService`
- [x] `POST /jobs/:jobId/bookmark` — create bookmark, protected
  - Validasi: job exists dan belum soft-deleted
  - Unique constraint DB mencegah duplikat (P2002)
  - Invalidate cache: `bookmarks:{userId}:*`
- [x] `DELETE /jobs/:jobId/bookmark` — hard delete bookmark, protected (self only)
  - Invalidate cache: `bookmarks:{userId}:*`
- [x] `GET /jobs/:jobId/bookmark/:id` — detail bookmark, protected (dengan validasi jobId)
- [x] `GET /bookmarks` — list all bookmarks milik user yang login, paginated
  - Redis cache: key `bookmarks:{userId}:p{page}:l{limit}`, TTL 3600s
  - Header `X-Data-Source: cache` jika hit

---

## 🎯 Acceptance Criteria Verified
- [x] Bookmark job yang sudah soft-deleted mengembalikan `404`
- [x] Bookmark job yang sama dua kali mengembalikan `409`
- [x] `DELETE /jobs/:jobId/bookmark` oleh user yang bukan pemilik mengembalikan `404` *(intentional: findFirst scope by userUuid, tidak ada info disclosure)*
- [x] `GET /bookmarks` cache hit mengembalikan header `X-Data-Source: cache`
- [x] Response tidak mengandung integer `id`

---

## 🧪 How to Test

**Unit & E2E:**
```bash
# Unit tests (30 tests)
npx jest src/modules/bookmarks/ --no-coverage

# E2E tests (22 tests)
npx jest test/e2e/bookmarks.e2e-spec.ts --config test/e2e/jest-e2e.json --no-coverage --forceExit
```

**Newman (full collection):**
```bash
npm run test:newman
# Cari section "Bookmarks" — semua 17 test items harus pass
```

**Manual Postman:**
1. Import `test/postman/OpenJob.postman_collection.json` dan `OpenJob.postman_environment.json`
2. Run full collection atau folder "Bookmarks" saja (setelah auth token tersedia)

---

## 🔍 Reviewer Checklist
- [x] Code follows naming conventions (SysDesign §6.1)
- [x] No integer `id` is exposed in the response
- [x] No hardcoded credentials
- [x] Soft delete queries filter `deletedAt IS NULL` (job lookup via `findJobOrFail`)
- [x] Response shape matches `{ status, data }` / `{ status, message }`
- [x] All new env vars have been added to `.env.example`