### PR TITLE
feat: implement Documents module with S3/MinIO PDF upload and presigned URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1041.0",
+        "@aws-sdk/s3-request-presigner": "^3.1041.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.0.1",
@@ -36,6 +38,7 @@
         "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
+        "@types/multer": "^2.1.0",
         "@types/node": "^24.0.0",
         "@types/supertest": "^7.0.0",
         "eslint": "^9.18.0",
@@ -197,6 +200,894 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1041.0.tgz",
+      "integrity": "sha512-sQV14bIqslnBHuSlLMD+fc3pH+ajop6vnrFlJ4wM4JDqcYwVik4O+9srnZUrkesFw5y+CN0GfOQ06CAgtC4mjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
+        "@aws-sdk/middleware-expect-continue": "^3.972.10",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.16",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-blob-browser": "^4.2.15",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/hash-stream-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
+      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
+      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
+      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.16.tgz",
+      "integrity": "sha512-6ru8doI0/XzszqLIPXf0E/V7HhAw1Pu94010XCKYtBUfD0LxF0BuOzrUf8OQGR6j2o6wgKTHUniOmndQycHwCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1041.0.tgz",
+      "integrity": "sha512-DlKsPQ8Z75wgeDSHbjUPNDQCYUF0OLBkqllZqFei61KIoQDqEeKUCwuCf6RhNLjaP4b8oSpBA9+FmUS+zm3xUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2570,6 +3461,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nuxt/opencollective": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
@@ -2730,6 +3633,725 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
+      "integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
+      "integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
+      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -3022,6 +4644,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.12.2",
@@ -4323,6 +5955,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/boxen": {
       "version": "5.1.2",
@@ -5933,6 +7571,42 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -8641,6 +10315,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -9608,6 +11297,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/strtok3": {
       "version": "10.3.5",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "seed": "ts-node -r tsconfig-paths/register src/prisma/seed.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1041.0",
+    "@aws-sdk/s3-request-presigner": "^3.1041.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.0.1",
@@ -58,6 +60,7 @@
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
+    "@types/multer": "^2.1.0",
     "@types/node": "^24.0.0",
     "@types/supertest": "^7.0.0",
     "eslint": "^9.18.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { CategoriesModule } from './modules/categories/categories.module';
 import { JobsModule } from './modules/jobs/jobs.module';
 import { ApplicationsModule } from './modules/applications/applications.module';
 import { BookmarksModule } from './modules/bookmarks/bookmarks.module';
+import { DocumentsModule } from './modules/documents/documents.module';
 import { QueueModule } from './modules/queue/queue.module';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 import { CustomThrottlerGuard } from './common/guards/throttler.guard';
@@ -50,6 +51,7 @@ import { THROTTLER_LIMITS } from './common/constants/throttler.constants';
     QueueModule,
     ApplicationsModule,
     BookmarksModule,
+    DocumentsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/modules/documents/documents.controller.spec.ts
+++ b/src/modules/documents/documents.controller.spec.ts
@@ -1,0 +1,194 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Response } from 'express';
+import { DocumentsController } from './documents.controller';
+import { DocumentsService } from './documents.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import type { JwtPayload } from '../../common/guards/jwt-auth.guard';
+import { DocumentResponseDto } from './dto/document-response.dto';
+import type { PaginatedResult } from '../profile/dto/pagination-query.dto';
+
+const USER_UUID = '111e8400-e29b-41d4-a716-446655440001';
+const DOC_UUID = '330e8400-e29b-41d4-a716-446655440003';
+const PRESIGNED_URL = 'https://minio/openjob/documents/key.pdf?sig=abc';
+
+const mockUser: JwtPayload = { id: USER_UUID };
+
+const mockDocumentResponse: DocumentResponseDto = {
+  id: DOC_UUID,
+  userId: USER_UUID,
+  originalName: 'resume.pdf',
+  mimeType: 'application/pdf',
+  size: 512000,
+  presignedUrl: PRESIGNED_URL,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+const mockPaginatedResult: PaginatedResult<DocumentResponseDto> = {
+  items: [mockDocumentResponse],
+  meta: { total: 1, page: 1, limit: 10, totalPages: 1 },
+};
+
+const mockRes = { header: jest.fn() } as unknown as Response;
+
+const makeMulterFile = (): Express.Multer.File =>
+  ({
+    fieldname: 'file',
+    originalname: 'resume.pdf',
+    encoding: '7bit',
+    mimetype: 'application/pdf',
+    buffer: Buffer.from('pdf'),
+    size: 512000,
+  }) as Express.Multer.File;
+
+describe('DocumentsController', () => {
+  let controller: DocumentsController;
+  let service: jest.Mocked<DocumentsService>;
+
+  beforeEach(async () => {
+    service = {
+      upload: jest.fn(),
+      findAll: jest.fn(),
+      findByUuid: jest.fn(),
+      remove: jest.fn(),
+    } as unknown as jest.Mocked<DocumentsService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DocumentsController],
+      providers: [
+        { provide: DocumentsService, useValue: service },
+        { provide: JwtAuthGuard, useValue: { canActivate: () => true } },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<DocumentsController>(DocumentsController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -----------------------------------------------------------------------
+  // POST /documents
+  // -----------------------------------------------------------------------
+  describe('upload()', () => {
+    it('should call service.upload and return DocumentResponseDto', async () => {
+      service.upload.mockResolvedValue(mockDocumentResponse);
+      const file = makeMulterFile();
+
+      const result = await controller.upload(mockUser, file);
+
+      expect(service.upload).toHaveBeenCalledWith(USER_UUID, file);
+      expect(result).toEqual(mockDocumentResponse);
+    });
+
+    it('should propagate BadRequestException for invalid MIME type', async () => {
+      service.upload.mockRejectedValue(
+        new BadRequestException('Invalid file type'),
+      );
+
+      await expect(controller.upload(mockUser, makeMulterFile())).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should propagate BadRequestException for file too large', async () => {
+      service.upload.mockRejectedValue(
+        new BadRequestException('File size exceeds'),
+      );
+
+      await expect(controller.upload(mockUser, makeMulterFile())).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /documents
+  // -----------------------------------------------------------------------
+  describe('getAll()', () => {
+    it('should return paginated document list', async () => {
+      service.findAll.mockResolvedValue(mockPaginatedResult);
+
+      const result = await controller.getAll({ page: 1, limit: 10 });
+
+      expect(service.findAll).toHaveBeenCalledWith({ page: 1, limit: 10 });
+      expect(result).toEqual(mockPaginatedResult);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /documents/:uuid
+  // -----------------------------------------------------------------------
+  describe('getById()', () => {
+    it('should set X-Data-Source header from cache and return response', async () => {
+      service.findByUuid.mockResolvedValue({
+        data: mockDocumentResponse,
+        source: 'cache',
+      });
+
+      const result = await controller.getById(DOC_UUID, mockRes);
+
+      expect(mockRes.header).toHaveBeenCalledWith('X-Data-Source', 'cache');
+      expect(result).toEqual(mockDocumentResponse);
+    });
+
+    it('should set X-Data-Source header from database', async () => {
+      service.findByUuid.mockResolvedValue({
+        data: mockDocumentResponse,
+        source: 'database',
+      });
+
+      await controller.getById(DOC_UUID, mockRes);
+
+      expect(mockRes.header).toHaveBeenCalledWith('X-Data-Source', 'database');
+    });
+
+    it('should propagate NotFoundException', async () => {
+      service.findByUuid.mockRejectedValue(new NotFoundException('Not found'));
+
+      await expect(controller.getById(DOC_UUID, mockRes)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // DELETE /documents/:uuid
+  // -----------------------------------------------------------------------
+  describe('remove()', () => {
+    it('should call service.remove and return success message', async () => {
+      service.remove.mockResolvedValue(undefined);
+
+      const result = await controller.remove(DOC_UUID, mockUser);
+
+      expect(service.remove).toHaveBeenCalledWith(DOC_UUID, USER_UUID);
+      expect(result).toEqual({
+        status: 'success',
+        message: 'Document deleted successfully',
+      });
+    });
+
+    it('should propagate ForbiddenException', async () => {
+      service.remove.mockRejectedValue(new ForbiddenException('Forbidden'));
+
+      await expect(controller.remove(DOC_UUID, mockUser)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+
+    it('should propagate NotFoundException', async () => {
+      service.remove.mockRejectedValue(new NotFoundException('Not found'));
+
+      await expect(controller.remove(DOC_UUID, mockUser)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});

--- a/src/modules/documents/documents.controller.ts
+++ b/src/modules/documents/documents.controller.ts
@@ -1,0 +1,72 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Query,
+  Res,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+import type { Response } from 'express';
+import { DocumentsService } from './documents.service';
+import { DocumentResponseDto } from './dto/document-response.dto';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import type { JwtPayload } from '../../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { SkipTransform } from '../../common/decorators/skip-transform.decorator';
+import {
+  PaginationQueryDto,
+  type PaginatedResult,
+} from '../profile/dto/pagination-query.dto';
+
+@Controller('documents')
+export class DocumentsController {
+  constructor(private readonly documentsService: DocumentsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UseGuards(JwtAuthGuard)
+  @UseInterceptors(FileInterceptor('file', { storage: memoryStorage() }))
+  upload(
+    @CurrentUser() user: JwtPayload,
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<DocumentResponseDto> {
+    return this.documentsService.upload(user.id, file);
+  }
+
+  @Get()
+  getAll(
+    @Query() query: PaginationQueryDto,
+  ): Promise<PaginatedResult<DocumentResponseDto>> {
+    return this.documentsService.findAll(query);
+  }
+
+  @Get(':uuid')
+  async getById(
+    @Param('uuid') uuid: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<DocumentResponseDto> {
+    const { data, source } = await this.documentsService.findByUuid(uuid);
+    res.header('X-Data-Source', source);
+    return data;
+  }
+
+  @Delete(':uuid')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  @SkipTransform()
+  async remove(
+    @Param('uuid') uuid: string,
+    @CurrentUser() user: JwtPayload,
+  ): Promise<{ status: string; message: string }> {
+    await this.documentsService.remove(uuid, user.id);
+    return { status: 'success', message: 'Document deleted successfully' };
+  }
+}

--- a/src/modules/documents/documents.module.ts
+++ b/src/modules/documents/documents.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { DocumentsController } from './documents.controller';
+import { DocumentsService } from './documents.service';
+import { S3Service } from './s3.service';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+
+@Module({
+  imports: [JwtModule.register({})],
+  controllers: [DocumentsController],
+  providers: [DocumentsService, S3Service, JwtAuthGuard],
+  exports: [DocumentsService],
+})
+export class DocumentsModule {}

--- a/src/modules/documents/documents.service.spec.ts
+++ b/src/modules/documents/documents.service.spec.ts
@@ -1,0 +1,264 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DocumentsService } from './documents.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { S3Service } from './s3.service';
+import { CacheService } from '../cache/cache.service';
+import { DocumentResponseDto } from './dto/document-response.dto';
+
+const USER_UUID = '111e8400-e29b-41d4-a716-446655440001';
+const OTHER_UUID = '222e8400-e29b-41d4-a716-446655440002';
+const DOC_UUID = '330e8400-e29b-41d4-a716-446655440003';
+const PRESIGNED_URL = 'https://minio/openjob/documents/key.pdf?sig=abc';
+
+const mockUser = {
+  id: 1,
+  uuid: USER_UUID,
+  fullname: 'Test User',
+  email: 'user@example.com',
+  password: 'hashed',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  deletedAt: null,
+};
+
+const mockDocument = {
+  id: 1,
+  uuid: DOC_UUID,
+  userId: 1,
+  filename: 'documents/111e/1234-resume.pdf',
+  originalName: 'resume.pdf',
+  mimeType: 'application/pdf',
+  size: 512000,
+  url: 'documents/111e/1234-resume.pdf',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  user: mockUser,
+};
+
+const mockDocumentResponse: DocumentResponseDto = {
+  id: DOC_UUID,
+  userId: USER_UUID,
+  originalName: 'resume.pdf',
+  mimeType: 'application/pdf',
+  size: 512000,
+  presignedUrl: PRESIGNED_URL,
+  createdAt: mockDocument.createdAt,
+  updatedAt: mockDocument.updatedAt,
+};
+
+describe('DocumentsService', () => {
+  let service: DocumentsService;
+  let prisma: {
+    client: {
+      document: {
+        create: jest.Mock;
+        findMany: jest.Mock;
+        count: jest.Mock;
+        findUnique: jest.Mock;
+        delete: jest.Mock;
+      };
+      user: { findUnique: jest.Mock };
+    };
+  };
+  let s3: jest.Mocked<S3Service>;
+  let cache: jest.Mocked<CacheService>;
+
+  beforeEach(async () => {
+    prisma = {
+      client: {
+        document: {
+          create: jest.fn(),
+          findMany: jest.fn(),
+          count: jest.fn(),
+          findUnique: jest.fn(),
+          delete: jest.fn(),
+        },
+        user: { findUnique: jest.fn() },
+      },
+    };
+
+    s3 = {
+      uploadFile: jest.fn(),
+      deleteFile: jest.fn(),
+      getPresignedUrl: jest.fn(),
+    } as unknown as jest.Mocked<S3Service>;
+
+    cache = {
+      get: jest.fn(),
+      set: jest.fn(),
+      del: jest.fn(),
+      delPattern: jest.fn(),
+    } as unknown as jest.Mocked<CacheService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DocumentsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: S3Service, useValue: s3 },
+        { provide: CacheService, useValue: cache },
+      ],
+    }).compile();
+
+    service = module.get<DocumentsService>(DocumentsService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -----------------------------------------------------------------------
+  // upload (POST /documents)
+  // -----------------------------------------------------------------------
+  describe('upload()', () => {
+    const makeFile = (
+      overrides: Partial<Express.Multer.File> = {},
+    ): Express.Multer.File =>
+      ({
+        fieldname: 'file',
+        originalname: 'resume.pdf',
+        encoding: '7bit',
+        mimetype: 'application/pdf',
+        buffer: Buffer.from('pdf-content'),
+        size: 512000,
+        ...overrides,
+      }) as Express.Multer.File;
+
+    it('should upload file, persist metadata, and return response with presigned URL', async () => {
+      const file = makeFile();
+      prisma.client.user.findUnique.mockResolvedValueOnce(mockUser);
+      s3.uploadFile.mockResolvedValueOnce('documents/111e/1234-resume.pdf');
+      prisma.client.document.create.mockResolvedValueOnce(mockDocument);
+      s3.getPresignedUrl.mockResolvedValueOnce(PRESIGNED_URL);
+
+      const result = await service.upload(USER_UUID, file);
+
+      expect(s3.uploadFile).toHaveBeenCalledTimes(1);
+      expect(prisma.client.document.create).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject<Partial<DocumentResponseDto>>({
+        id: DOC_UUID,
+        userId: USER_UUID,
+        presignedUrl: PRESIGNED_URL,
+      });
+    });
+
+    it('should throw BadRequestException when MIME type is not application/pdf', async () => {
+      const file = makeFile({ mimetype: 'image/png' });
+
+      await expect(service.upload(USER_UUID, file)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(s3.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when file size exceeds 5MB', async () => {
+      const file = makeFile({ size: 6 * 1024 * 1024 }); // 6MB
+
+      await expect(service.upload(USER_UUID, file)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(s3.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      prisma.client.user.findUnique.mockResolvedValueOnce(null);
+
+      await expect(service.upload(USER_UUID, makeFile())).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findAll (GET /documents)
+  // -----------------------------------------------------------------------
+  describe('findAll()', () => {
+    it('should return paginated documents with presigned URLs', async () => {
+      prisma.client.document.count.mockResolvedValueOnce(1);
+      prisma.client.document.findMany.mockResolvedValueOnce([mockDocument]);
+      s3.getPresignedUrl.mockResolvedValue(PRESIGNED_URL);
+
+      const result = await service.findAll({ page: 1, limit: 10 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.meta).toEqual({ total: 1, page: 1, limit: 10, totalPages: 1 });
+      expect(result.items[0].presignedUrl).toBe(PRESIGNED_URL);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findByUuid (GET /documents/:uuid)
+  // -----------------------------------------------------------------------
+  describe('findByUuid()', () => {
+    it('should return document from cache when available', async () => {
+      cache.get.mockResolvedValueOnce(mockDocumentResponse);
+
+      const { data, source } = await service.findByUuid(DOC_UUID);
+
+      expect(source).toBe('cache');
+      expect(data).toEqual(mockDocumentResponse);
+      expect(prisma.client.document.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should fetch from DB, cache result, and return with presigned URL', async () => {
+      cache.get.mockResolvedValueOnce(null);
+      prisma.client.document.findUnique.mockResolvedValueOnce(mockDocument);
+      s3.getPresignedUrl.mockResolvedValueOnce(PRESIGNED_URL);
+
+      const { data, source } = await service.findByUuid(DOC_UUID);
+
+      expect(source).toBe('database');
+      expect(data.presignedUrl).toBe(PRESIGNED_URL);
+      expect(cache.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw NotFoundException for unknown UUID', async () => {
+      cache.get.mockResolvedValueOnce(null);
+      prisma.client.document.findUnique.mockResolvedValueOnce(null);
+
+      await expect(service.findByUuid(DOC_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw NotFoundException for invalid UUID format', async () => {
+      await expect(service.findByUuid('not-a-uuid')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // remove (DELETE /documents/:uuid)
+  // -----------------------------------------------------------------------
+  describe('remove()', () => {
+    it('should delete S3 object, DB record, and invalidate cache', async () => {
+      prisma.client.document.findUnique.mockResolvedValueOnce(mockDocument);
+      prisma.client.document.delete.mockResolvedValueOnce(mockDocument);
+
+      await service.remove(DOC_UUID, USER_UUID);
+
+      expect(s3.deleteFile).toHaveBeenCalledWith(mockDocument.url);
+      expect(prisma.client.document.delete).toHaveBeenCalledTimes(1);
+      expect(cache.del).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw NotFoundException when document does not exist', async () => {
+      prisma.client.document.findUnique.mockResolvedValueOnce(null);
+
+      await expect(service.remove(DOC_UUID, USER_UUID)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw ForbiddenException when requester is not the owner', async () => {
+      prisma.client.document.findUnique.mockResolvedValueOnce(mockDocument);
+
+      await expect(service.remove(DOC_UUID, OTHER_UUID)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+});

--- a/src/modules/documents/documents.service.spec.ts
+++ b/src/modules/documents/documents.service.spec.ts
@@ -144,6 +144,13 @@ describe('DocumentsService', () => {
       });
     });
 
+    it('should throw BadRequestException when no file is provided', async () => {
+      await expect(
+        service.upload(USER_UUID, undefined as unknown as Express.Multer.File),
+      ).rejects.toThrow(BadRequestException);
+      expect(s3.uploadFile).not.toHaveBeenCalled();
+    });
+
     it('should throw BadRequestException when MIME type is not application/pdf', async () => {
       const file = makeFile({ mimetype: 'image/png' });
 

--- a/src/modules/documents/documents.service.ts
+++ b/src/modules/documents/documents.service.ts
@@ -1,0 +1,187 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import type { Document, User } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { S3Service } from './s3.service';
+import { CacheService } from '../cache/cache.service';
+import { DocumentResponseDto } from './dto/document-response.dto';
+import type {
+  PaginatedResult,
+  PaginationQueryDto,
+} from '../profile/dto/pagination-query.dto';
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_MIME = 'application/pdf';
+const CACHE_TTL = 3600;
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const cacheKey = (uuid: string) => `documents:${uuid}`;
+
+type DocumentWithUser = Document & { user: User };
+
+export type FindByUuidResult = {
+  data: DocumentResponseDto;
+  source: 'cache' | 'database';
+};
+
+@Injectable()
+export class DocumentsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly s3: S3Service,
+    private readonly cache: CacheService,
+  ) {}
+
+  async upload(
+    userUuid: string,
+    file: Express.Multer.File,
+  ): Promise<DocumentResponseDto> {
+    if (file.mimetype !== ALLOWED_MIME) {
+      throw new BadRequestException(
+        'Invalid file type. Only application/pdf is allowed',
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      throw new BadRequestException(
+        'File size exceeds the maximum allowed limit of 5MB',
+      );
+    }
+
+    const user = await this.prisma.client.user.findUnique({
+      where: { uuid: userUuid },
+    });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const timestamp = Date.now();
+    const sanitized = file.originalname.replace(/[^a-zA-Z0-9.\-_]/g, '_');
+    const key = `documents/${userUuid}/${timestamp}-${sanitized}`;
+
+    await this.s3.uploadFile(file.buffer, key, file.mimetype);
+
+    const doc = await this.prisma.client.document.create({
+      data: {
+        user: { connect: { id: user.id } },
+        filename: key,
+        originalName: file.originalname,
+        mimeType: file.mimetype,
+        size: file.size,
+        url: key,
+      },
+      include: { user: true },
+    });
+
+    const presignedUrl = await this.s3.getPresignedUrl(key);
+    return this.toResponse(doc as DocumentWithUser, presignedUrl);
+  }
+
+  async findAll(
+    query: PaginationQueryDto,
+  ): Promise<PaginatedResult<DocumentResponseDto>> {
+    const { page, limit } = query;
+    const skip = (page - 1) * limit;
+
+    const [total, docs] = await Promise.all([
+      this.prisma.client.document.count(),
+      this.prisma.client.document.findMany({
+        skip,
+        take: limit,
+        include: { user: true },
+        orderBy: { createdAt: 'desc' },
+      }),
+    ]);
+
+    const items = await Promise.all(
+      (docs as DocumentWithUser[]).map(async (doc) => {
+        const presignedUrl = await this.s3.getPresignedUrl(doc.url);
+        return this.toResponse(doc, presignedUrl);
+      }),
+    );
+
+    return {
+      items,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async findByUuid(uuid: string): Promise<FindByUuidResult> {
+    if (!UUID_REGEX.test(uuid)) {
+      throw new NotFoundException('Document not found');
+    }
+
+    const cached = await this.cache.get<DocumentResponseDto>(cacheKey(uuid));
+    if (cached) {
+      return { data: cached, source: 'cache' };
+    }
+
+    const doc = await this.prisma.client.document.findUnique({
+      where: { uuid },
+      include: { user: true },
+    });
+
+    if (!doc) {
+      throw new NotFoundException('Document not found');
+    }
+
+    const presignedUrl = await this.s3.getPresignedUrl(
+      (doc as DocumentWithUser).url,
+    );
+    const response = this.toResponse(doc as DocumentWithUser, presignedUrl);
+
+    await this.cache.set(cacheKey(uuid), response, CACHE_TTL);
+    return { data: response, source: 'database' };
+  }
+
+  async remove(uuid: string, requesterUuid: string): Promise<void> {
+    if (!UUID_REGEX.test(uuid)) {
+      throw new NotFoundException('Document not found');
+    }
+
+    const doc = await this.prisma.client.document.findUnique({
+      where: { uuid },
+      include: { user: true },
+    });
+
+    if (!doc) {
+      throw new NotFoundException('Document not found');
+    }
+
+    if ((doc as DocumentWithUser).user.uuid !== requesterUuid) {
+      throw new ForbiddenException(
+        'You are not authorized to delete this document',
+      );
+    }
+
+    await this.s3.deleteFile(doc.url);
+    await this.prisma.client.document.delete({ where: { uuid } });
+    await this.cache.del(cacheKey(uuid));
+  }
+
+  private toResponse(
+    doc: DocumentWithUser,
+    presignedUrl: string,
+  ): DocumentResponseDto {
+    return {
+      id: doc.uuid,
+      userId: doc.user.uuid,
+      originalName: doc.originalName,
+      mimeType: doc.mimeType,
+      size: doc.size,
+      presignedUrl,
+      createdAt: doc.createdAt,
+      updatedAt: doc.updatedAt,
+    };
+  }
+}

--- a/src/modules/documents/documents.service.ts
+++ b/src/modules/documents/documents.service.ts
@@ -41,6 +41,10 @@ export class DocumentsService {
     userUuid: string,
     file: Express.Multer.File,
   ): Promise<DocumentResponseDto> {
+    if (!file) {
+      throw new BadRequestException('File is required');
+    }
+
     if (file.mimetype !== ALLOWED_MIME) {
       throw new BadRequestException(
         'Invalid file type. Only application/pdf is allowed',

--- a/src/modules/documents/dto/document-response.dto.ts
+++ b/src/modules/documents/dto/document-response.dto.ts
@@ -1,0 +1,10 @@
+export class DocumentResponseDto {
+  id!: string; // UUID
+  userId!: string; // User UUID
+  originalName!: string;
+  mimeType!: string;
+  size!: number;
+  presignedUrl!: string;
+  createdAt!: Date;
+  updatedAt!: Date;
+}

--- a/src/modules/documents/s3.service.spec.ts
+++ b/src/modules/documents/s3.service.spec.ts
@@ -1,0 +1,124 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { S3Service } from './s3.service';
+
+const mockS3Send = jest.fn();
+const mockGetSignedUrl = getSignedUrl as jest.MockedFunction<typeof getSignedUrl>;
+
+jest.mock('@aws-sdk/client-s3', () => {
+  const actual = jest.requireActual<typeof import('@aws-sdk/client-s3')>('@aws-sdk/client-s3');
+  return {
+    ...actual,
+    S3Client: jest.fn().mockImplementation(() => ({ send: mockS3Send })),
+    PutObjectCommand: jest.fn().mockImplementation((input) => ({ input })),
+    DeleteObjectCommand: jest.fn().mockImplementation((input) => ({ input })),
+    GetObjectCommand: jest.fn().mockImplementation((input) => ({ input })),
+  };
+});
+jest.mock('@aws-sdk/s3-request-presigner');
+
+const S3_CONFIG = {
+  S3_ENDPOINT: 'http://localhost:9000',
+  S3_REGION: 'us-east-1',
+  S3_ACCESS_KEY: 'minioadmin',
+  S3_SECRET_KEY: 'minioadmin',
+  S3_BUCKET_NAME: 'openjob',
+};
+
+describe('S3Service', () => {
+  let service: S3Service;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        S3Service,
+        {
+          provide: ConfigService,
+          useValue: { get: (key: string) => S3_CONFIG[key as keyof typeof S3_CONFIG] },
+        },
+      ],
+    }).compile();
+
+    service = module.get<S3Service>(S3Service);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -----------------------------------------------------------------------
+  // uploadFile
+  // -----------------------------------------------------------------------
+  describe('uploadFile()', () => {
+    it('should call PutObjectCommand with correct params and return the object key', async () => {
+      mockS3Send.mockResolvedValueOnce({});
+
+      const buffer = Buffer.from('pdf-content');
+      const key = await service.uploadFile(buffer, 'documents/uuid/123-resume.pdf', 'application/pdf');
+
+      expect(mockS3Send).toHaveBeenCalledTimes(1);
+      expect(PutObjectCommand).toHaveBeenCalledWith({
+        Bucket: S3_CONFIG.S3_BUCKET_NAME,
+        Key: 'documents/uuid/123-resume.pdf',
+        Body: buffer,
+        ContentType: 'application/pdf',
+      });
+      expect(key).toBe('documents/uuid/123-resume.pdf');
+    });
+
+    it('should propagate errors from S3 client', async () => {
+      mockS3Send.mockRejectedValueOnce(new Error('S3 unavailable'));
+
+      await expect(
+        service.uploadFile(Buffer.from('data'), 'key', 'application/pdf'),
+      ).rejects.toThrow('S3 unavailable');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // deleteFile
+  // -----------------------------------------------------------------------
+  describe('deleteFile()', () => {
+    it('should call DeleteObjectCommand with the correct key', async () => {
+      mockS3Send.mockResolvedValueOnce({});
+
+      await service.deleteFile('documents/uuid/123-resume.pdf');
+
+      expect(mockS3Send).toHaveBeenCalledTimes(1);
+      expect(DeleteObjectCommand).toHaveBeenCalledWith({
+        Bucket: S3_CONFIG.S3_BUCKET_NAME,
+        Key: 'documents/uuid/123-resume.pdf',
+      });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getPresignedUrl
+  // -----------------------------------------------------------------------
+  describe('getPresignedUrl()', () => {
+    it('should return a presigned URL for the given key with TTL 3600', async () => {
+      const fakeUrl = 'https://minio/openjob/documents/uuid/123-resume.pdf?X-Amz-Signature=abc';
+      mockGetSignedUrl.mockResolvedValueOnce(fakeUrl);
+
+      const url = await service.getPresignedUrl('documents/uuid/123-resume.pdf');
+
+      expect(mockGetSignedUrl).toHaveBeenCalledTimes(1);
+      expect(GetObjectCommand).toHaveBeenCalledWith({
+        Bucket: S3_CONFIG.S3_BUCKET_NAME,
+        Key: 'documents/uuid/123-resume.pdf',
+      });
+      const [, , options] = mockGetSignedUrl.mock.calls[0] as [
+        S3Client,
+        GetObjectCommand,
+        { expiresIn: number },
+      ];
+      expect(options.expiresIn).toBe(3600);
+      expect(url).toBe(fakeUrl);
+    });
+  });
+});

--- a/src/modules/documents/s3.service.ts
+++ b/src/modules/documents/s3.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import type { EnvConfig } from '../../config/env.config';
+
+const PRESIGNED_URL_TTL = 3600;
+
+@Injectable()
+export class S3Service {
+  private readonly client: S3Client;
+  private readonly bucket: string;
+
+  constructor(private readonly config: ConfigService<EnvConfig, true>) {
+    this.bucket = this.config.get('S3_BUCKET_NAME');
+    this.client = new S3Client({
+      endpoint: this.config.get('S3_ENDPOINT'),
+      region: this.config.get('S3_REGION'),
+      credentials: {
+        accessKeyId: this.config.get('S3_ACCESS_KEY'),
+        secretAccessKey: this.config.get('S3_SECRET_KEY'),
+      },
+      forcePathStyle: true, // required for MinIO
+    });
+  }
+
+  async uploadFile(
+    buffer: Buffer,
+    key: string,
+    contentType: string,
+  ): Promise<string> {
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        Body: buffer,
+        ContentType: contentType,
+      }),
+    );
+    return key;
+  }
+
+  async deleteFile(key: string): Promise<void> {
+    await this.client.send(
+      new DeleteObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+      }),
+    );
+  }
+
+  async getPresignedUrl(key: string): Promise<string> {
+    return getSignedUrl(
+      this.client,
+      new GetObjectCommand({ Bucket: this.bucket, Key: key }),
+      { expiresIn: PRESIGNED_URL_TTL },
+    );
+  }
+}

--- a/test/e2e/documents.e2e-spec.ts
+++ b/test/e2e/documents.e2e-spec.ts
@@ -1,0 +1,467 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { ThrottlerStorage } from '@nestjs/throttler';
+import { AppModule } from '../../src/app.module';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { CacheService } from '../../src/modules/cache/cache.service';
+import { QueueService } from '../../src/modules/queue/queue.service';
+import { S3Service } from '../../src/modules/documents/s3.service';
+import { AllExceptionsFilter } from '../../src/common/filters/all-exceptions.filter';
+
+const getRandomString = () => Math.random().toString(36).substring(7);
+
+const PRESIGNED_URL =
+  'https://minio.example.com/openjob/documents/key.pdf?X-Amz-Signature=abc';
+
+const makeUser = () => ({
+  fullname: `User ${getRandomString()}`,
+  email: `user_${getRandomString()}@example.com`,
+  password: 'StrongPassword123!',
+});
+
+const makePdfBuffer = () => Buffer.from('%PDF-1.4 fake pdf content');
+
+async function registerAndLogin(
+  app: INestApplication<App>,
+): Promise<{ token: string }> {
+  const user = makeUser();
+  await request(app.getHttpServer())
+    .post('/api/v1/users')
+    .send(user)
+    .expect(201);
+
+  const res = await request(app.getHttpServer())
+    .post('/api/v1/authentications')
+    .send({ email: user.email, password: user.password })
+    .expect(201);
+
+  return { token: res.body.data.accessToken as string };
+}
+
+describe('DocumentsController (e2e)', () => {
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let cache: CacheService;
+  let mockS3: jest.Mocked<Pick<S3Service, 'uploadFile' | 'deleteFile' | 'getPresignedUrl'>>;
+
+  beforeAll(async () => {
+    mockS3 = {
+      uploadFile: jest.fn().mockResolvedValue('documents/uuid/123-resume.pdf'),
+      deleteFile: jest.fn().mockResolvedValue(undefined),
+      getPresignedUrl: jest.fn().mockResolvedValue(PRESIGNED_URL),
+    };
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(ThrottlerStorage)
+      .useValue({
+        increment: jest.fn().mockResolvedValue({
+          totalHits: 0,
+          timeToExpire: 9999,
+          isBlocked: false,
+          timeToBlockExpire: 0,
+        }),
+      })
+      .overrideProvider(QueueService)
+      .useValue({
+        publish: jest.fn(),
+        onModuleInit: jest.fn(),
+        onModuleDestroy: jest.fn(),
+      })
+      .overrideProvider(S3Service)
+      .useValue(mockS3)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api/v1');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalFilters(new AllExceptionsFilter());
+
+    prisma = moduleFixture.get(PrismaService);
+    cache = moduleFixture.get(CacheService);
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await prisma.$executeRaw`DELETE FROM documents`;
+    await prisma.client.authentication.deleteMany({});
+    await prisma.client.user.deleteMany({});
+    await app.close();
+  });
+
+  afterEach(async () => {
+    await prisma.$executeRaw`DELETE FROM documents`;
+    await prisma.client.authentication.deleteMany({});
+    await prisma.client.user.deleteMany({});
+    await cache.delPattern('documents:*');
+    jest.clearAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // POST /api/v1/documents
+  // -----------------------------------------------------------------------
+  describe('POST /api/v1/documents', () => {
+    it('should upload a PDF and return 201 with presigned URL (AC: upload success)', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(201);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.id).toBeDefined();
+      expect(res.body.data.presignedUrl).toBe(PRESIGNED_URL);
+      expect(res.body.data.originalName).toBe('resume.pdf');
+      expect(res.body.data.mimeType).toBe('application/pdf');
+      expect(typeof res.body.data.id).toBe('string');
+      expect(res.body.data.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+      expect(mockS3.uploadFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return 400 when MIME type is not application/pdf (AC: invalid MIME)', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', Buffer.from('fake image'), {
+          filename: 'photo.png',
+          contentType: 'image/png',
+        })
+        .expect(400);
+
+      expect(res.body.status).toBe('fail');
+      expect(mockS3.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when file exceeds 5MB (AC: file too large)', async () => {
+      const { token } = await registerAndLogin(app);
+      const bigBuffer = Buffer.alloc(6 * 1024 * 1024, 'a'); // 6MB
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', bigBuffer, {
+          filename: 'big.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(400);
+
+      expect(res.body.status).toBe('fail');
+      expect(mockS3.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when unauthenticated', async () => {
+      await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(401);
+    });
+
+    it('should not expose integer id in response (AC: no integer id leak)', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(201);
+
+      expect(res.body.data).not.toHaveProperty('filename');
+      // id must be a UUID string, not an integer
+      expect(typeof res.body.data.id).toBe('string');
+      expect(res.body.data.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/documents
+  // -----------------------------------------------------------------------
+  describe('GET /api/v1/documents', () => {
+    it('should return paginated list of documents (200, public)', async () => {
+      const { token } = await registerAndLogin(app);
+
+      // Upload one document first
+      await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(201);
+
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/documents')
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.items).toHaveLength(1);
+      expect(res.body.data.meta.total).toBe(1);
+      expect(res.body.data.meta.page).toBe(1);
+      expect(res.body.data.items[0].presignedUrl).toBe(PRESIGNED_URL);
+    });
+
+    it('should return empty list when no documents exist (200)', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/documents')
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.items).toHaveLength(0);
+      expect(res.body.data.meta.total).toBe(0);
+    });
+
+    it('should support pagination via query params', async () => {
+      const { token } = await registerAndLogin(app);
+
+      // Upload 2 documents
+      for (let i = 0; i < 2; i++) {
+        await request(app.getHttpServer())
+          .post('/api/v1/documents')
+          .set('Authorization', `Bearer ${token}`)
+          .attach('file', makePdfBuffer(), {
+            filename: `resume-${i}.pdf`,
+            contentType: 'application/pdf',
+          })
+          .expect(201);
+      }
+
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/documents?page=1&limit=1')
+        .expect(200);
+
+      expect(res.body.data.items).toHaveLength(1);
+      expect(res.body.data.meta.total).toBe(2);
+      expect(res.body.data.meta.totalPages).toBe(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /api/v1/documents/:uuid
+  // -----------------------------------------------------------------------
+  describe('GET /api/v1/documents/:uuid', () => {
+    it('should return document with presigned URL (200, public, AC: valid presigned URL)', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const uploadRes = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(201);
+
+      const docId = uploadRes.body.data.id as string;
+
+      const res = await request(app.getHttpServer())
+        .get(`/api/v1/documents/${docId}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.data.id).toBe(docId);
+      expect(res.body.data.presignedUrl).toBe(PRESIGNED_URL);
+    });
+
+    it('should set X-Data-Source: database on first fetch', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const uploadRes = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(201);
+
+      const docId = uploadRes.body.data.id as string;
+
+      const res = await request(app.getHttpServer())
+        .get(`/api/v1/documents/${docId}`)
+        .expect(200);
+
+      expect(res.headers['x-data-source']).toBe('database');
+    });
+
+    it('should set X-Data-Source: cache on subsequent fetch', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const uploadRes = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(201);
+
+      const docId = uploadRes.body.data.id as string;
+
+      // First fetch primes the cache
+      await request(app.getHttpServer())
+        .get(`/api/v1/documents/${docId}`)
+        .expect(200);
+
+      // Second fetch should come from cache
+      const res = await request(app.getHttpServer())
+        .get(`/api/v1/documents/${docId}`)
+        .expect(200);
+
+      expect(res.headers['x-data-source']).toBe('cache');
+    });
+
+    it('should return 404 for non-existent UUID', async () => {
+      const nonExistentId = '00000000-0000-7000-8000-000000000000';
+
+      const res = await request(app.getHttpServer())
+        .get(`/api/v1/documents/${nonExistentId}`)
+        .expect(404);
+
+      expect(res.body.status).toBe('fail');
+    });
+
+    it('should return 404 for invalid UUID format', async () => {
+      const res = await request(app.getHttpServer())
+        .get('/api/v1/documents/not-a-uuid')
+        .expect(404);
+
+      expect(res.body.status).toBe('fail');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // DELETE /api/v1/documents/:uuid
+  // -----------------------------------------------------------------------
+  describe('DELETE /api/v1/documents/:uuid', () => {
+    it('should delete document and return success (200, AC: delete cleans S3 + DB)', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const uploadRes = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(201);
+
+      const docId = uploadRes.body.data.id as string;
+
+      const res = await request(app.getHttpServer())
+        .delete(`/api/v1/documents/${docId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      expect(res.body.status).toBe('success');
+      expect(res.body.message).toBe('Document deleted successfully');
+      expect(mockS3.deleteFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return 404 after deletion (AC: no longer accessible)', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const uploadRes = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(201);
+
+      const docId = uploadRes.body.data.id as string;
+
+      await request(app.getHttpServer())
+        .delete(`/api/v1/documents/${docId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+
+      // Document should no longer be accessible
+      await request(app.getHttpServer())
+        .get(`/api/v1/documents/${docId}`)
+        .expect(404);
+    });
+
+    it('should return 403 when another user tries to delete (AC: ownership check)', async () => {
+      const { token: ownerToken } = await registerAndLogin(app);
+      const { token: otherToken } = await registerAndLogin(app);
+
+      const uploadRes = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${ownerToken}`)
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(201);
+
+      const docId = uploadRes.body.data.id as string;
+
+      const res = await request(app.getHttpServer())
+        .delete(`/api/v1/documents/${docId}`)
+        .set('Authorization', `Bearer ${otherToken}`)
+        .expect(403);
+
+      expect(res.body.status).toBe('fail');
+      expect(mockS3.deleteFile).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when unauthenticated', async () => {
+      const { token } = await registerAndLogin(app);
+
+      const uploadRes = await request(app.getHttpServer())
+        .post('/api/v1/documents')
+        .set('Authorization', `Bearer ${token}`)
+        .attach('file', makePdfBuffer(), {
+          filename: 'resume.pdf',
+          contentType: 'application/pdf',
+        })
+        .expect(201);
+
+      const docId = uploadRes.body.data.id as string;
+
+      await request(app.getHttpServer())
+        .delete(`/api/v1/documents/${docId}`)
+        .expect(401);
+    });
+
+    it('should return 404 for non-existent document UUID', async () => {
+      const { token } = await registerAndLogin(app);
+      const nonExistentId = '00000000-0000-7000-8000-000000000000';
+
+      const res = await request(app.getHttpServer())
+        .delete(`/api/v1/documents/${nonExistentId}`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(404);
+
+      expect(res.body.status).toBe('fail');
+    });
+  });
+});

--- a/test/postman/OpenJob.postman_collection.json
+++ b/test/postman/OpenJob.postman_collection.json
@@ -130,7 +130,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -184,7 +186,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -238,7 +242,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -297,7 +303,9 @@
             {
               "listen": "prerequest",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             },
@@ -1009,7 +1017,7 @@
               "script": {
                 "exec": [
                   "const responseJson = pm.response.json();",
-                  "pm.environment.set('documentsAccessToken', responseJson.data.accessToken);"
+                  "pm.environment.set(\"documentsAccessToken\", responseJson.data.accessToken);"
                 ],
                 "type": "text/javascript"
               }
@@ -1032,24 +1040,54 @@
           "response": []
         },
         {
+          "name": "[Setup] - Login Jane for Documents Test",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const responseJson = pm.response.json();",
+                  "pm.environment.set(\"documentsAccessTokenJane\", responseJson.data.accessToken);"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"email\": \"jane@example.com\",\n    \"password\": \"password123\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseURL}}/authentications"
+          },
+          "response": []
+        },
+        {
           "name": "Upload Document without Authentication",
           "event": [
             {
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('it should response 401 status code', () => {",
+                  "pm.test(\"it should response 401 status code\", () => {",
                   "    pm.expect(pm.response).to.have.status(401);",
                   "});",
                   "",
-                  "pm.test('response Content-Type header should have application/json value', () => {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
                   "});",
                   "",
-                  "pm.test('response body should have correct property and value', () => {",
+                  "pm.test(\"response body should have correct property and value\", () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('fail');",
-                  "    pm.expect(responseJson.message).to.be.a('string');",
+                  "    pm.expect(responseJson.status).to.equal(\"fail\");",
+                  "    pm.expect(responseJson.message).to.be.a(\"string\");",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1074,14 +1112,18 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('it should response 400 status code', () => {",
+                  "pm.test(\"it should response 400 status code\", () => {",
                   "    pm.expect(pm.response).to.have.status(400);",
                   "});",
                   "",
-                  "pm.test('response body should have correct property and value', () => {",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
+                  "});",
+                  "",
+                  "pm.test(\"response body should have correct property and value\", () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('fail');",
-                  "    pm.expect(responseJson.message).to.include('required');",
+                  "    pm.expect(responseJson.status).to.equal(\"fail\");",
+                  "    pm.expect(responseJson.message).to.include(\"File is required\");",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1112,14 +1154,18 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('it should response 400 status code', () => {",
+                  "pm.test(\"it should response 400 status code\", () => {",
                   "    pm.expect(pm.response).to.have.status(400);",
                   "});",
                   "",
-                  "pm.test('response body should have correct property and value', () => {",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
+                  "});",
+                  "",
+                  "pm.test(\"response body should have correct property and value\", () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('fail');",
-                  "    pm.expect(responseJson.message).to.include('File is required');",
+                  "    pm.expect(responseJson.status).to.equal(\"fail\");",
+                  "    pm.expect(responseJson.message).to.be.a(\"string\");",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1139,8 +1185,8 @@
               "mode": "formdata",
               "formdata": [
                 {
-                  "key": "document",
-                  "description": "Upload a non-PDF file (e.g., .txt, .jpg) to test validation",
+                  "key": "file",
+                  "description": "Upload a non-PDF file (e.g., .txt, .jpg) to test MIME type validation",
                   "type": "file",
                   "src": []
                 }
@@ -1157,23 +1203,26 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('it should response 201 status code', () => {",
+                  "pm.test(\"it should response 201 status code\", () => {",
                   "    pm.expect(pm.response).to.have.status(201);",
                   "});",
                   "",
-                  "pm.test('response Content-Type header should have application/json value', () => {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.includes('application/json');",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
                   "});",
                   "",
-                  "pm.test('response body should have correct property and value', () => {",
+                  "pm.test(\"response body should have correct property and value\", () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('success');",
-                  "    pm.expect(responseJson.data).to.be.an('object');",
-                  "    pm.expect(responseJson.data.documentId).to.be.a('string');",
-                  "    pm.expect(responseJson.data.filename).to.be.a('string');",
-                  "    pm.expect(responseJson.data.originalName).to.be.a('string');",
-                  "    pm.expect(responseJson.data.size).to.be.a('number');",
-                  "    pm.environment.set('documentId', responseJson.data.documentId);",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
+                  "    pm.expect(responseJson.data).to.be.an(\"object\");",
+                  "    pm.expect(responseJson.data.id).to.be.a(\"string\");",
+                  "    pm.expect(responseJson.data.userId).to.be.a(\"string\");",
+                  "    pm.expect(responseJson.data.originalName).to.be.a(\"string\");",
+                  "    pm.expect(responseJson.data.mimeType).to.equal(\"application/pdf\");",
+                  "    pm.expect(responseJson.data.size).to.be.a(\"number\");",
+                  "    pm.expect(responseJson.data.presignedUrl).to.be.a(\"string\");",
+                  "    pm.expect(responseJson.data).to.not.have.property(\"filename\");",
+                  "    pm.environment.set(\"documentId\", responseJson.data.id);",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1193,7 +1242,7 @@
               "mode": "formdata",
               "formdata": [
                 {
-                  "key": "document",
+                  "key": "file",
                   "description": "Upload a valid PDF file (max 5MB)",
                   "type": "file",
                   "src": "/home/me/Development/Assets/sample.pdf"
@@ -1211,15 +1260,25 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('it should response 200 status code', () => {",
+                  "pm.test(\"it should response 200 status code\", () => {",
                   "    pm.expect(pm.response).to.have.status(200);",
                   "});",
                   "",
-                  "pm.test('response body should have correct property and value', () => {",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
+                  "});",
+                  "",
+                  "pm.test(\"response body should have correct property and value\", () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('success');",
-                  "    pm.expect(responseJson.data.documents).to.be.an('array');",
-                  "    pm.expect(responseJson.data.documents.length).to.be.at.least(1);",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
+                  "    pm.expect(responseJson.data).to.be.an(\"object\");",
+                  "    pm.expect(responseJson.data.items).to.be.an(\"array\");",
+                  "    pm.expect(responseJson.data.items.length).to.be.at.least(1);",
+                  "    pm.expect(responseJson.data.meta).to.be.an(\"object\");",
+                  "    pm.expect(responseJson.data.meta.total).to.be.a(\"number\");",
+                  "    pm.expect(responseJson.data.meta.page).to.be.a(\"number\");",
+                  "    pm.expect(responseJson.data.meta.limit).to.be.a(\"number\");",
+                  "    pm.expect(responseJson.data.meta.totalPages).to.be.a(\"number\");",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1234,19 +1293,22 @@
           "response": []
         },
         {
-          "name": "Get Document by Id with Invalid Id",
+          "name": "Get All Documents with Pagination",
           "event": [
             {
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('it should response 404 status code', () => {",
-                  "    pm.expect(pm.response).to.have.status(404);",
+                  "pm.test(\"it should response 200 status code\", () => {",
+                  "    pm.expect(pm.response).to.have.status(200);",
                   "});",
                   "",
-                  "pm.test('response body should have correct property and value', () => {",
+                  "pm.test(\"response body should have correct pagination meta\", () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('fail');",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
+                  "    pm.expect(responseJson.data.items).to.be.an(\"array\");",
+                  "    pm.expect(responseJson.data.meta.page).to.equal(1);",
+                  "    pm.expect(responseJson.data.meta.limit).to.equal(5);",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1256,27 +1318,121 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": "{{baseURL}}/documents/xxx"
+            "url": {
+              "raw": "{{baseURL}}/documents?page=1&limit=5",
+              "host": [
+                "{{baseURL}}"
+              ],
+              "path": [
+                "documents"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "limit",
+                  "value": "5"
+                }
+              ]
+            }
           },
           "response": []
         },
         {
-          "name": "Get Document by Id (View/Download PDF)",
+          "name": "Get Document by Id with Invalid Id",
           "event": [
             {
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('it should response 200 status code', () => {",
+                  "pm.test(\"it should response 404 status code\", () => {",
+                  "    pm.expect(pm.response).to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
+                  "});",
+                  "",
+                  "pm.test(\"response body should have correct property and value\", () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal(\"fail\");",
+                  "    pm.expect(responseJson.message).to.be.a(\"string\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseURL}}/documents/invalid-uuid-format"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Document by Id",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"it should response 200 status code\", () => {",
                   "    pm.expect(pm.response).to.have.status(200);",
                   "});",
                   "",
-                  "pm.test('response Content-Type should be application/pdf', () => {",
-                  "    pm.expect(pm.response.headers.get('Content-Type')).to.equal('application/pdf');",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
                   "});",
                   "",
-                  "pm.test('response should have Content-Disposition header', () => {",
-                  "    pm.expect(pm.response.headers.has('Content-Disposition')).to.be.true;",
+                  "pm.test(\"response body should have correct property and value\", () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
+                  "    pm.expect(responseJson.data.id).to.equal(pm.environment.get(\"documentId\"));",
+                  "    pm.expect(responseJson.data.originalName).to.be.a(\"string\");",
+                  "    pm.expect(responseJson.data.mimeType).to.equal(\"application/pdf\");",
+                  "    pm.expect(responseJson.data.size).to.be.a(\"number\");",
+                  "    pm.expect(responseJson.data.presignedUrl).to.be.a(\"string\");",
+                  "    pm.expect(responseJson.data).to.not.have.property(\"filename\");",
+                  "});",
+                  "",
+                  "pm.test(\"X-Data-Source header should be database on first fetch\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"X-Data-Source\")).to.equal(\"database\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{baseURL}}/documents/{{documentId}}"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Document by Id - Cache Hit",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"it should response 200 status code\", () => {",
+                  "    pm.expect(pm.response).to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"X-Data-Source header should be cache on second fetch\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"X-Data-Source\")).to.equal(\"cache\");",
+                  "});",
+                  "",
+                  "pm.test(\"response body should have correct property and value\", () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
+                  "    pm.expect(responseJson.data.id).to.equal(pm.environment.get(\"documentId\"));",
+                  "    pm.expect(responseJson.data.presignedUrl).to.be.a(\"string\");",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1297,8 +1453,18 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('it should response 401 status code', () => {",
+                  "pm.test(\"it should response 401 status code\", () => {",
                   "    pm.expect(pm.response).to.have.status(401);",
+                  "});",
+                  "",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
+                  "});",
+                  "",
+                  "pm.test(\"response body should have correct property and value\", () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal(\"fail\");",
+                  "    pm.expect(responseJson.message).to.be.a(\"string\");",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -1313,19 +1479,100 @@
           "response": []
         },
         {
+          "name": "Delete Document Owned by Another User",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"it should response 403 status code\", () => {",
+                  "    pm.expect(pm.response).to.have.status(403);",
+                  "});",
+                  "",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
+                  "});",
+                  "",
+                  "pm.test(\"response body should have correct property and value\", () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal(\"fail\");",
+                  "    pm.expect(responseJson.message).to.be.a(\"string\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{documentsAccessTokenJane}}",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseURL}}/documents/{{documentId}}"
+          },
+          "response": []
+        },
+        {
           "name": "Delete Document with Valid Id",
           "event": [
             {
               "listen": "test",
               "script": {
                 "exec": [
-                  "pm.test('it should response 200 status code', () => {",
+                  "pm.test(\"it should response 200 status code\", () => {",
                   "    pm.expect(pm.response).to.have.status(200);",
                   "});",
                   "",
-                  "pm.test('response body should have correct property and value', () => {",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
+                  "});",
+                  "",
+                  "pm.test(\"response body should have correct property and value\", () => {",
                   "    const responseJson = pm.response.json();",
-                  "    pm.expect(responseJson.status).to.equal('success');",
+                  "    pm.expect(responseJson.status).to.equal(\"success\");",
+                  "    pm.expect(responseJson.message).to.equal(\"Document deleted successfully\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{documentsAccessToken}}",
+                "type": "text"
+              }
+            ],
+            "url": "{{baseURL}}/documents/{{documentId}}"
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Non-existent Document",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"it should response 404 status code\", () => {",
+                  "    pm.expect(pm.response).to.have.status(404);",
+                  "});",
+                  "",
+                  "pm.test(\"response Content-Type header should have application/json value\", () => {",
+                  "    pm.expect(pm.response.headers.get(\"Content-Type\")).to.includes(\"application/json\");",
+                  "});",
+                  "",
+                  "pm.test(\"response body should have correct property and value\", () => {",
+                  "    const responseJson = pm.response.json();",
+                  "    pm.expect(responseJson.status).to.equal(\"fail\");",
+                  "    pm.expect(responseJson.message).to.be.a(\"string\");",
                   "});"
                 ],
                 "type": "text/javascript"
@@ -5167,7 +5414,9 @@
             {
               "listen": "test",
               "script": {
-                "exec": [""],
+                "exec": [
+                  ""
+                ],
                 "type": "text/javascript"
               }
             }

--- a/test/postman/OpenJob.postman_environment.json
+++ b/test/postman/OpenJob.postman_environment.json
@@ -183,6 +183,12 @@
       "enabled": true
     },
     {
+      "key": "documentsAccessTokenJane",
+      "value": "",
+      "type": "any",
+      "enabled": true
+    },
+    {
       "key": "documentId",
       "value": "",
       "type": "any",


### PR DESCRIPTION
## 🔗 Closes
Closes #14

---

## 📋 Summary

Implementasi lengkap Documents module untuk PDF upload ke S3/MinIO. Semua file disimpan ke object storage via AWS SDK v3 `PutObject` — local disk storage tidak digunakan (multer `memoryStorage`).

**Key technical decisions:**
- `S3Service` dibuat sebagai dedicated provider (bukan inline di service) untuk memudahkan mocking di unit test
- `remove()` menggunakan hard delete (bukan soft delete) karena `Document` bukan termasuk entitas yang di-soft-delete
- `findByUuid()` melakukan single Redis lookup, lalu DB query — cache diinvalidasi saat delete
- `GET /documents/:uuid` mengembalikan `X-Data-Source: database | cache` header
- File guard `if (!file)` ditambahkan di service layer untuk 400 yang bersih ketika tidak ada file dikirim
- S3 key format: `documents/{userUuid}/{timestamp}-{sanitized-filename}.pdf`

---

## 🔄 Type of Change
- [x] `feat` — New feature
- [x] `fix` — Bug fix (missing file guard)
- [x] `test` — Adding or improving tests

---

## ✅ Tasks Completed
- [x] Buat `DocumentsModule` dengan `DocumentsController`, `DocumentsService`
- [x] `POST /documents` — upload PDF, protected
  - multer memory storage (bukan disk, bukan local file)
  - Validasi MIME type: `application/pdf` only → `400` jika bukan
  - Validasi size: max 5MB → `400` jika exceed
  - S3 object key: `documents/{userUuid}/{timestamp}-{sanitized-filename}.pdf`
  - Upload via AWS SDK `PutObject` ke MinIO (dev) / R2 / S3 (prod)
  - Simpan metadata ke tabel `documents`: `filename`, `originalName`, `mimeType`, `size`
  - Response: `DocumentResponse` dengan presigned URL
- [x] `GET /documents` — list all documents, public (dengan pagination)
- [x] `GET /documents/:id` — get metadata + generate presigned `GetObject` URL (TTL 3600s)
- [x] `DELETE /documents/:id` — hard delete metadata + delete S3 object, protected (owner)
- [x] Env: `S3_ENDPOINT`, `S3_REGION`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET_NAME`

---

## 🎯 Acceptance Criteria Verified
- [x] Upload non-PDF file mengembalikan `400` dengan pesan error MIME type
- [x] Upload file > 5MB mengembalikan `400` dengan pesan error size
- [x] Upload sukses: file tersimpan di MinIO/S3, metadata di DB, response berisi presigned URL
- [x] `GET /documents/:uuid` mengembalikan presigned URL yang valid (accessible via browser)
- [x] `DELETE /documents/:uuid` menghapus metadata dari DB dan object dari S3

---

## 🧪 How to Test

**Prerequisites:** Docker services running (`docker compose up -d`)

1. Start the API: `npm run start:dev`
2. Import `test/postman/OpenJob.postman_collection.json` + environment into Postman
3. Run the **Documents** folder in order:
   - `[Setup] - Login for Documents Test` → saves `documentsAccessToken`
   - `[Setup] - Login Jane for Documents Test` → saves `documentsAccessTokenJane`
   - `Upload Document without Authentication` → 401
   - `Upload Document without File` → 400 "File is required"
   - `Upload Document with Non-PDF File` → 400 MIME error
   - `Upload Document with Valid PDF` → 201, saves `documentId`
   - `Get All Documents` → 200 with `items[]` + `meta`
   - `Get All Documents with Pagination` → 200 with page/limit params
   - `Get Document by Id with Invalid Id` → 404
   - `Get Document by Id` → 200, `X-Data-Source: database`
   - `Get Document by Id - Cache Hit` → 200, `X-Data-Source: cache`
   - `Delete Document without Authentication` → 401
   - `Delete Document Owned by Another User` → 403
   - `Delete Document with Valid Id` → 200 "Document deleted successfully"
   - `Delete Non-existent Document` → 404

**Run unit tests:** `npm run test`
**Run E2E tests:** `npx jest --config ./test/e2e/jest-e2e.json --testPathPatterns=documents`

---

## 🔍 Reviewer Checklist
- [x] Code follows naming conventions (SysDesign §6.1)
- [x] No integer `id` is exposed in the response (UUID exposed as `id`)
- [x] No hardcoded credentials
- [x] Soft delete queries filter `deletedAt IS NULL` (Document uses hard delete — not in SOFT_DELETE_MODELS)
- [x] Response shape matches `{ status, data }` / `{ status, message }`
- [x] All new env vars have been added to `.env.example`