### PR TITLE
[FEAT] Redis caching module

### DIFF
--- a/src/modules/cache/cache.service.spec.ts
+++ b/src/modules/cache/cache.service.spec.ts
@@ -1,0 +1,223 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import Redis from 'ioredis';
+import { CacheService } from './cache.service';
+
+jest.mock('ioredis');
+
+const mockRedis = {
+  on: jest.fn(),
+  quit: jest.fn(),
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  scan: jest.fn(),
+};
+
+describe('CacheService', () => {
+  let service: CacheService;
+
+  beforeEach(async () => {
+    // Re-register the constructor implementation so it survives resetAllMocks()
+    jest.mocked(Redis).mockImplementation(() => mockRedis as unknown as Redis);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CacheService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn().mockImplementation((key: string) => {
+              const config: Record<string, string | number> = {
+                REDIS_HOST: 'localhost',
+                REDIS_PORT: 6379,
+              };
+              return config[key];
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<CacheService>(CacheService);
+    service.onModuleInit();
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  // -----------------------------------------------------------------------
+  // onModuleInit()
+  // -----------------------------------------------------------------------
+  describe('onModuleInit()', () => {
+    it('should initialise Redis client with host and port from config', () => {
+      const Redis = jest.requireMock<jest.Mock>('ioredis');
+      expect(Redis).toHaveBeenCalledWith(
+        expect.objectContaining({ host: 'localhost', port: 6379 }),
+      );
+    });
+
+    it('should register an error listener so connection errors are logged instead of crashing', () => {
+      expect(mockRedis.on).toHaveBeenCalledWith('error', expect.any(Function));
+    });
+
+    it('should not throw even when Redis host is unreachable (lazyConnect)', () => {
+      expect(() => service.onModuleInit()).not.toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // onModuleDestroy()
+  // -----------------------------------------------------------------------
+  describe('onModuleDestroy()', () => {
+    it('should call client.quit() on destroy', async () => {
+      await service.onModuleDestroy();
+      expect(mockRedis.quit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // get()
+  // -----------------------------------------------------------------------
+  describe('get()', () => {
+    it('should return parsed value on cache hit', async () => {
+      mockRedis.get.mockResolvedValue(JSON.stringify({ name: 'test' }));
+
+      const result = await service.get<{ name: string }>('some:key');
+
+      expect(mockRedis.get).toHaveBeenCalledWith('some:key');
+      expect(result).toEqual({ name: 'test' });
+    });
+
+    it('should return null on cache miss', async () => {
+      mockRedis.get.mockResolvedValue(null);
+
+      const result = await service.get('missing:key');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null and log a warning when Redis throws', async () => {
+      const warnSpy = jest
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(() => undefined);
+      mockRedis.get.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const result = await service.get('some:key');
+
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Cache GET failed'),
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // set()
+  // -----------------------------------------------------------------------
+  describe('set()', () => {
+    it('should serialise the value and call client.set with correct EX ttl', async () => {
+      mockRedis.set.mockResolvedValue('OK');
+
+      await service.set('some:key', { name: 'test' }, 3600);
+
+      expect(mockRedis.set).toHaveBeenCalledWith(
+        'some:key',
+        JSON.stringify({ name: 'test' }),
+        'EX',
+        3600,
+      );
+    });
+
+    it('should not throw and should log a warning when Redis throws', async () => {
+      const warnSpy = jest
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(() => undefined);
+      mockRedis.set.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(service.set('some:key', {}, 3600)).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Cache SET failed'),
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // del()
+  // -----------------------------------------------------------------------
+  describe('del()', () => {
+    it('should call client.del with the provided key', async () => {
+      mockRedis.del.mockResolvedValue(1);
+
+      await service.del('some:key');
+
+      expect(mockRedis.del).toHaveBeenCalledWith('some:key');
+    });
+
+    it('should not throw and should log a warning when Redis throws', async () => {
+      const warnSpy = jest
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(() => undefined);
+      mockRedis.del.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(service.del('some:key')).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Cache DEL failed'),
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // delPattern()
+  // -----------------------------------------------------------------------
+  describe('delPattern()', () => {
+    it('should scan and delete all keys matching the pattern', async () => {
+      mockRedis.scan.mockResolvedValue(['0', ['key:1', 'key:2']]);
+      mockRedis.del.mockResolvedValue(1);
+
+      await service.delPattern('key:*');
+
+      expect(mockRedis.scan).toHaveBeenCalledWith(
+        '0',
+        'MATCH',
+        'key:*',
+        'COUNT',
+        100,
+      );
+      expect(mockRedis.del).toHaveBeenCalledWith('key:1');
+      expect(mockRedis.del).toHaveBeenCalledWith('key:2');
+    });
+
+    it('should handle multiple scan pages (cursor != 0)', async () => {
+      mockRedis.scan
+        .mockResolvedValueOnce(['42', ['key:1']])
+        .mockResolvedValueOnce(['0', ['key:2']]);
+      mockRedis.del.mockResolvedValue(1);
+
+      await service.delPattern('key:*');
+
+      expect(mockRedis.scan).toHaveBeenCalledTimes(2);
+      expect(mockRedis.del).toHaveBeenCalledTimes(2);
+    });
+
+    it('should do nothing when no keys match the pattern', async () => {
+      mockRedis.scan.mockResolvedValue(['0', []]);
+
+      await service.delPattern('nonexistent:*');
+
+      expect(mockRedis.del).not.toHaveBeenCalled();
+    });
+
+    it('should not throw and should log a warning when Redis throws', async () => {
+      const warnSpy = jest
+        .spyOn(Logger.prototype, 'warn')
+        .mockImplementation(() => undefined);
+      mockRedis.scan.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(service.delPattern('key:*')).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Cache DELPATTERN failed'),
+      );
+    });
+  });
+});

--- a/src/modules/cache/cache.service.ts
+++ b/src/modules/cache/cache.service.ts
@@ -35,17 +35,36 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
   }
 
   async get<T>(key: string): Promise<T | null> {
-    const value = await this.client.get(key);
-    if (!value) return null;
-    return JSON.parse(value) as T;
+    try {
+      const value = await this.client.get(key);
+      if (!value) return null;
+      return JSON.parse(value) as T;
+    } catch (err) {
+      this.logger.warn(
+        `Cache GET failed for key "${key}": ${(err as Error).message}`,
+      );
+      return null;
+    }
   }
 
   async set(key: string, value: unknown, ttlSeconds: number): Promise<void> {
-    await this.client.set(key, JSON.stringify(value), 'EX', ttlSeconds);
+    try {
+      await this.client.set(key, JSON.stringify(value), 'EX', ttlSeconds);
+    } catch (err) {
+      this.logger.warn(
+        `Cache SET failed for key "${key}": ${(err as Error).message}`,
+      );
+    }
   }
 
   async del(key: string): Promise<void> {
-    await this.client.del(key);
+    try {
+      await this.client.del(key);
+    } catch (err) {
+      this.logger.warn(
+        `Cache DEL failed for key "${key}": ${(err as Error).message}`,
+      );
+    }
   }
 
   /**
@@ -53,23 +72,29 @@ export class CacheService implements OnModuleInit, OnModuleDestroy {
    * Use for paginated cache invalidation, e.g. `applications:user:{uuid}:*`.
    */
   async delPattern(pattern: string): Promise<void> {
-    let cursor = '0';
-    const matchedKeys: string[] = [];
+    try {
+      let cursor = '0';
+      const matchedKeys: string[] = [];
 
-    do {
-      const [nextCursor, keys] = await this.client.scan(
-        cursor,
-        'MATCH',
-        pattern,
-        'COUNT',
-        100,
+      do {
+        const [nextCursor, keys] = await this.client.scan(
+          cursor,
+          'MATCH',
+          pattern,
+          'COUNT',
+          100,
+        );
+        cursor = nextCursor;
+        matchedKeys.push(...keys);
+      } while (cursor !== '0');
+
+      if (matchedKeys.length > 0) {
+        await Promise.all(matchedKeys.map((key) => this.client.del(key)));
+      }
+    } catch (err) {
+      this.logger.warn(
+        `Cache DELPATTERN failed for pattern "${pattern}": ${(err as Error).message}`,
       );
-      cursor = nextCursor;
-      matchedKeys.push(...keys);
-    } while (cursor !== '0');
-
-    if (matchedKeys.length > 0) {
-      await Promise.all(matchedKeys.map((key) => this.client.del(key)));
     }
   }
 }

--- a/src/modules/documents/documents.controller.spec.ts
+++ b/src/modules/documents/documents.controller.spec.ts
@@ -93,9 +93,9 @@ describe('DocumentsController', () => {
         new BadRequestException('Invalid file type'),
       );
 
-      await expect(controller.upload(mockUser, makeMulterFile())).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        controller.upload(mockUser, makeMulterFile()),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('should propagate BadRequestException for file too large', async () => {
@@ -103,9 +103,9 @@ describe('DocumentsController', () => {
         new BadRequestException('File size exceeds'),
       );
 
-      await expect(controller.upload(mockUser, makeMulterFile())).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        controller.upload(mockUser, makeMulterFile()),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/src/modules/documents/documents.service.spec.ts
+++ b/src/modules/documents/documents.service.spec.ts
@@ -190,7 +190,12 @@ describe('DocumentsService', () => {
       const result = await service.findAll({ page: 1, limit: 10 });
 
       expect(result.items).toHaveLength(1);
-      expect(result.meta).toEqual({ total: 1, page: 1, limit: 10, totalPages: 1 });
+      expect(result.meta).toEqual({
+        total: 1,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+      });
       expect(result.items[0].presignedUrl).toBe(PRESIGNED_URL);
     });
   });

--- a/src/modules/documents/documents.service.ts
+++ b/src/modules/documents/documents.service.ts
@@ -83,7 +83,7 @@ export class DocumentsService {
     });
 
     const presignedUrl = await this.s3.getPresignedUrl(key);
-    return this.toResponse(doc as DocumentWithUser, presignedUrl);
+    return this.toResponse(doc, presignedUrl);
   }
 
   async findAll(
@@ -139,10 +139,8 @@ export class DocumentsService {
       throw new NotFoundException('Document not found');
     }
 
-    const presignedUrl = await this.s3.getPresignedUrl(
-      (doc as DocumentWithUser).url,
-    );
-    const response = this.toResponse(doc as DocumentWithUser, presignedUrl);
+    const presignedUrl = await this.s3.getPresignedUrl(doc.url);
+    const response = this.toResponse(doc, presignedUrl);
 
     await this.cache.set(cacheKey(uuid), response, CACHE_TTL);
     return { data: response, source: 'database' };
@@ -162,7 +160,7 @@ export class DocumentsService {
       throw new NotFoundException('Document not found');
     }
 
-    if ((doc as DocumentWithUser).user.uuid !== requesterUuid) {
+    if (doc.user.uuid !== requesterUuid) {
       throw new ForbiddenException(
         'You are not authorized to delete this document',
       );

--- a/src/modules/documents/s3.service.spec.ts
+++ b/src/modules/documents/s3.service.spec.ts
@@ -10,10 +10,15 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { S3Service } from './s3.service';
 
 const mockS3Send = jest.fn();
-const mockGetSignedUrl = getSignedUrl as jest.MockedFunction<typeof getSignedUrl>;
+const mockGetSignedUrl = getSignedUrl as jest.MockedFunction<
+  typeof getSignedUrl
+>;
 
 jest.mock('@aws-sdk/client-s3', () => {
-  const actual = jest.requireActual<typeof import('@aws-sdk/client-s3')>('@aws-sdk/client-s3');
+  const actual =
+    jest.requireActual<typeof import('@aws-sdk/client-s3')>(
+      '@aws-sdk/client-s3',
+    );
   return {
     ...actual,
     S3Client: jest.fn().mockImplementation(() => ({ send: mockS3Send })),
@@ -41,7 +46,9 @@ describe('S3Service', () => {
         S3Service,
         {
           provide: ConfigService,
-          useValue: { get: (key: string) => S3_CONFIG[key as keyof typeof S3_CONFIG] },
+          useValue: {
+            get: (key: string) => S3_CONFIG[key as keyof typeof S3_CONFIG],
+          },
         },
       ],
     }).compile();
@@ -59,7 +66,11 @@ describe('S3Service', () => {
       mockS3Send.mockResolvedValueOnce({});
 
       const buffer = Buffer.from('pdf-content');
-      const key = await service.uploadFile(buffer, 'documents/uuid/123-resume.pdf', 'application/pdf');
+      const key = await service.uploadFile(
+        buffer,
+        'documents/uuid/123-resume.pdf',
+        'application/pdf',
+      );
 
       expect(mockS3Send).toHaveBeenCalledTimes(1);
       expect(PutObjectCommand).toHaveBeenCalledWith({
@@ -102,10 +113,13 @@ describe('S3Service', () => {
   // -----------------------------------------------------------------------
   describe('getPresignedUrl()', () => {
     it('should return a presigned URL for the given key with TTL 3600', async () => {
-      const fakeUrl = 'https://minio/openjob/documents/uuid/123-resume.pdf?X-Amz-Signature=abc';
+      const fakeUrl =
+        'https://minio/openjob/documents/uuid/123-resume.pdf?X-Amz-Signature=abc';
       mockGetSignedUrl.mockResolvedValueOnce(fakeUrl);
 
-      const url = await service.getPresignedUrl('documents/uuid/123-resume.pdf');
+      const url = await service.getPresignedUrl(
+        'documents/uuid/123-resume.pdf',
+      );
 
       expect(mockGetSignedUrl).toHaveBeenCalledTimes(1);
       expect(GetObjectCommand).toHaveBeenCalledWith({

--- a/test/e2e/documents.e2e-spec.ts
+++ b/test/e2e/documents.e2e-spec.ts
@@ -44,7 +44,9 @@ describe('DocumentsController (e2e)', () => {
   let app: INestApplication<App>;
   let prisma: PrismaService;
   let cache: CacheService;
-  let mockS3: jest.Mocked<Pick<S3Service, 'uploadFile' | 'deleteFile' | 'getPresignedUrl'>>;
+  let mockS3: jest.Mocked<
+    Pick<S3Service, 'uploadFile' | 'deleteFile' | 'getPresignedUrl'>
+  >;
 
   beforeAll(async () => {
     mockS3 = {


### PR DESCRIPTION
## 🔗 Closes
Closes #15

---

## 📋 Summary

Implementasi Redis caching module sebagai shared global wrapper yang digunakan oleh semua modules (`Companies`, `Users`, `Applications`, `Bookmarks`).

**Technical decisions:**
- `CacheService` didaftarkan sebagai `@Global()` module sehingga bisa di-inject ke semua modules tanpa circular dependency
- Semua operasi Redis (`get/set/del/delPattern`) dibungkus `try/catch` — Redis failure di-log sebagai `WARN` dan dikembalikan fallback aman (`null`/`void`) agar tidak crash request cycle
- `delPattern` menggunakan `SCAN` cursor (non-blocking) untuk invalidasi paginated cache, menghindari `KEYS` yang memblokir Redis
- Cache key format: `[entity]:[uuid]` untuk single-record, `[entity]:[userUuid]:p[page]:l[limit]` untuk paginated list
- `X-Data-Source: cache | database` header diinjeksi di controller layer, bukan service layer, untuk separation of concerns

---

## 🔄 Type of Change
- [x] `feat` — New feature
- [x] `test` — Adding or improving tests

---

## ✅ Tasks Completed
- [x] Buat `CacheModule` (global) dengan `CacheService` yang menyediakan: `get(key)`, `set(key, value, ttl)`, `del(key)`
- [x] Koneksi ke Redis via env `REDIS_HOST`, `REDIS_PORT`
- [x] Cache diimplementasikan di semua endpoint target (Companies, Applications, Bookmarks, Users)
- [x] `X-Data-Source: cache` header diinjeksi ke response saat cache hit
- [x] Cache invalidation terpasang di semua mutation operations (CREATE/UPDATE/DELETE)

---

## 🎯 Acceptance Criteria Verified
- [x] `CacheService` bisa di-inject ke semua modules tanpa circular dependency
- [x] `GET /companies/:uuid` request kedua mengembalikan `X-Data-Source: cache`
- [x] `PUT /companies/:uuid` menyebabkan cache key `companies:{uuid}` terhapus
- [x] Redis connection error di startup tidak crash app — fallback gracefully (log warning)
- [x] TTL 3600s konsisten di semua cached endpoints

---

## 🧪 How to Test

1. Pastikan Redis running: `docker compose up -d redis`
2. Jalankan unit tests: `npx jest --no-coverage`
3. Jalankan e2e tests cache scenarios:
   ```
   npx jest --config test/e2e/jest-e2e.json --testPathPatterns="companies.e2e|users.e2e|applications.e2e|bookmarks.e2e" --forceExit
   ```
4. Manual via Postman:
   - `GET /api/v1/companies/:uuid` → first hit: `X-Data-Source: database`
   - `GET /api/v1/companies/:uuid` → second hit: `X-Data-Source: cache`
   - `PUT /api/v1/companies/:uuid` → `X-Data-Source` kembali `database` pada hit berikutnya

---

## 🔍 Reviewer Checklist
- [x] Code follows naming conventions (SysDesign §6.1)
- [x] No integer `id` is exposed in the response
- [x] No hardcoded credentials
- [x] Soft delete queries filter `deletedAt IS NULL`
- [x] Response shape matches `{ status, data }` / `{ status, message }`
- [x] All new env vars have been added to `.env.example`