### PR TITLE
[FEAT] RabbitMQ Producer & Consumer — application:created event + Nodemailer email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "ioredis": "^5.10.1",
+        "nodemailer": "^8.0.7",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "zod": "^4.3.6"
@@ -40,6 +41,7 @@
         "@types/jest": "^30.0.0",
         "@types/multer": "^2.1.0",
         "@types/node": "^24.0.0",
+        "@types/nodemailer": "^8.0.0",
         "@types/supertest": "^7.0.0",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -4662,6 +4664,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -10059,6 +10071,15 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
     "ioredis": "^5.10.1",
+    "nodemailer": "^8.0.7",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "zod": "^4.3.6"
@@ -62,6 +63,7 @@
     "@types/jest": "^30.0.0",
     "@types/multer": "^2.1.0",
     "@types/node": "^24.0.0",
+    "@types/nodemailer": "^8.0.0",
     "@types/supertest": "^7.0.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/src/modules/queue/notification.service.spec.ts
+++ b/src/modules/queue/notification.service.spec.ts
@@ -1,0 +1,332 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import * as amqplib from 'amqplib';
+import * as nodemailer from 'nodemailer';
+import { NotificationService } from './notification.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+jest.mock('amqplib');
+jest.mock('nodemailer');
+
+const APPLICANT_UUID = '111e8400-e29b-41d4-a716-446655440001';
+const OWNER_UUID = '222e8400-e29b-41d4-a716-446655440002';
+const JOB_UUID = '330e8400-e29b-41d4-a716-446655440003';
+const APPLICATION_UUID = '550e8400-e29b-41d4-a716-446655440005';
+
+const mockApplicant = {
+  id: 1,
+  uuid: APPLICANT_UUID,
+  fullname: 'Budi Santoso',
+  email: 'budi@example.com',
+  password: 'hashed',
+  createdAt: new Date('2026-01-15T00:00:00Z'),
+  updatedAt: new Date('2026-01-15T00:00:00Z'),
+  deletedAt: null,
+};
+
+const mockOwner = {
+  id: 2,
+  uuid: OWNER_UUID,
+  fullname: 'Company Owner',
+  email: 'owner@example.com',
+  password: 'hashed',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+  deletedAt: null,
+};
+
+const mockApplication = {
+  id: 1,
+  uuid: APPLICATION_UUID,
+  userId: 1,
+  jobId: 1,
+  status: 'pending',
+  createdAt: new Date('2026-01-15T00:00:00Z'),
+  updatedAt: new Date('2026-01-15T00:00:00Z'),
+  deletedAt: null,
+  user: mockApplicant,
+  job: {
+    id: 1,
+    uuid: JOB_UUID,
+    title: 'Software Engineer',
+    company: {
+      id: 1,
+      name: 'Test Company',
+      owner: mockOwner,
+    },
+  },
+};
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+  let mockChannel: jest.Mocked<amqplib.Channel>;
+  let mockConnection: jest.Mocked<amqplib.ChannelModel>;
+  let mockSendMail: jest.Mock;
+  let prisma: {
+    client: {
+      application: {
+        findUnique: jest.Mock;
+      };
+    };
+  };
+
+  beforeEach(async () => {
+    mockChannel = {
+      assertQueue: jest.fn().mockResolvedValue(undefined),
+      consume: jest.fn().mockResolvedValue(undefined),
+      ack: jest.fn(),
+      nack: jest.fn(),
+      publish: jest.fn().mockReturnValue(true),
+      close: jest.fn().mockResolvedValue(undefined),
+      prefetch: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<amqplib.Channel>;
+
+    mockConnection = {
+      createChannel: jest.fn().mockResolvedValue(mockChannel),
+      close: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<amqplib.ChannelModel>;
+
+    (amqplib.connect as jest.Mock).mockResolvedValue(mockConnection);
+
+    mockSendMail = jest.fn().mockResolvedValue({ messageId: 'test-id' });
+    (nodemailer.createTransport as jest.Mock).mockReturnValue({
+      sendMail: mockSendMail,
+    });
+
+    prisma = {
+      client: {
+        application: {
+          findUnique: jest.fn().mockResolvedValue(mockApplication),
+        },
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              const config: Record<string, string | number> = {
+                RABBITMQ_HOST: 'localhost',
+                RABBITMQ_PORT: 5672,
+                RABBITMQ_USER: 'guest',
+                RABBITMQ_PASSWORD: 'guest',
+                MAIL_HOST: 'localhost',
+                MAIL_PORT: 1025,
+                MAIL_USER: 'test@example.com',
+                MAIL_PASSWORD: 'password',
+              };
+              return config[key];
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<NotificationService>(NotificationService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onModuleInit', () => {
+    it('should connect to RabbitMQ and start consuming', async () => {
+      await service.onModuleInit();
+
+      expect(amqplib.connect).toHaveBeenCalled();
+      expect(mockChannel.prefetch).toHaveBeenCalledWith(1);
+      expect(mockChannel.consume).toHaveBeenCalledWith(
+        'application.created',
+        expect.any(Function),
+      );
+    });
+
+    it('should not throw if RabbitMQ connection fails', async () => {
+      (amqplib.connect as jest.Mock).mockRejectedValue(
+        new Error('Connection refused'),
+      );
+
+      await expect(service.onModuleInit()).resolves.not.toThrow();
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('should close channel and connection', async () => {
+      await service.onModuleInit();
+      await service.onModuleDestroy();
+
+      expect(mockChannel.close).toHaveBeenCalled();
+      expect(mockConnection.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('processMessage', () => {
+    function makeMessage(
+      payload: unknown,
+      retryCount = 0,
+    ): amqplib.Message {
+      return {
+        content: Buffer.from(JSON.stringify(payload)),
+        properties: {
+          headers: { 'x-retry-count': retryCount },
+          contentType: 'application/json',
+          deliveryMode: 2,
+          persistent: true,
+        },
+        fields: {
+          deliveryTag: 1,
+          exchange: 'openjob.events',
+          routingKey: 'application.created',
+          redelivered: false,
+          consumerTag: 'consumer-1',
+        },
+      } as unknown as amqplib.Message;
+    }
+
+    beforeEach(async () => {
+      await service.onModuleInit();
+    });
+
+    it('should ack message and send email on successful processing', async () => {
+      const msg = makeMessage({ applicationId: APPLICATION_UUID });
+
+      await service.processMessage(msg);
+
+      expect(prisma.client.application.findUnique).toHaveBeenCalledWith({
+        where: { uuid: APPLICATION_UUID },
+        include: {
+          user: true,
+          job: { include: { company: { include: { owner: true } } } },
+        },
+      });
+      expect(mockSendMail).toHaveBeenCalled();
+      expect(mockChannel.ack).toHaveBeenCalledWith(msg);
+      expect(mockChannel.nack).not.toHaveBeenCalled();
+    });
+
+    it('should send email to the job owner, not the applicant', async () => {
+      const msg = makeMessage({ applicationId: APPLICATION_UUID });
+
+      await service.processMessage(msg);
+
+      const mailOptions = mockSendMail.mock.calls[0][0] as { to: string };
+      expect(mailOptions.to).toBe(mockOwner.email);
+    });
+
+    it('should include applicant name, email, and application date in the email', async () => {
+      const msg = makeMessage({ applicationId: APPLICATION_UUID });
+
+      await service.processMessage(msg);
+
+      const mailOptions = mockSendMail.mock.calls[0][0] as {
+        html: string;
+        text: string;
+      };
+      const emailContent = mailOptions.html ?? mailOptions.text;
+      expect(emailContent).toContain(mockApplicant.fullname);
+      expect(emailContent).toContain(mockApplicant.email);
+      expect(emailContent).toContain(
+        mockApplication.createdAt.toISOString().split('T')[0],
+      );
+    });
+
+    it('should nack malformed JSON without retry', async () => {
+      const msg = {
+        content: Buffer.from('not-valid-json'),
+        properties: { headers: {} },
+        fields: { deliveryTag: 1, exchange: '', routingKey: '', redelivered: false, consumerTag: '' },
+      } as unknown as amqplib.Message;
+
+      await service.processMessage(msg);
+
+      expect(mockChannel.nack).toHaveBeenCalledWith(msg, false, false);
+      expect(mockChannel.ack).not.toHaveBeenCalled();
+      expect(mockSendMail).not.toHaveBeenCalled();
+    });
+
+    it('should nack message without retry when applicationId is missing', async () => {
+      const msg = makeMessage({ wrongField: 'value' });
+
+      await service.processMessage(msg);
+
+      expect(mockChannel.nack).toHaveBeenCalledWith(msg, false, false);
+      expect(mockChannel.ack).not.toHaveBeenCalled();
+    });
+
+    it('should ack and republish with incremented retry count on transient failure (retryCount=0)', async () => {
+      jest.useFakeTimers();
+      prisma.client.application.findUnique.mockRejectedValueOnce(
+        new Error('DB error'),
+      );
+      const msg = makeMessage({ applicationId: APPLICATION_UUID }, 0);
+
+      const processPromise = service.processMessage(msg);
+      jest.runAllTimers();
+      await processPromise;
+
+      expect(mockChannel.ack).toHaveBeenCalledWith(msg);
+      expect(mockChannel.publish).toHaveBeenCalledWith(
+        'openjob.events',
+        'application.created',
+        expect.any(Buffer),
+        expect.objectContaining({
+          headers: { 'x-retry-count': 1 },
+          persistent: true,
+        }),
+      );
+      jest.useRealTimers();
+    });
+
+    it('should ack and republish with incremented retry count on transient failure (retryCount=1)', async () => {
+      jest.useFakeTimers();
+      prisma.client.application.findUnique.mockRejectedValueOnce(
+        new Error('DB error'),
+      );
+      const msg = makeMessage({ applicationId: APPLICATION_UUID }, 1);
+
+      const processPromise = service.processMessage(msg);
+      jest.runAllTimers();
+      await processPromise;
+
+      expect(mockChannel.ack).toHaveBeenCalledWith(msg);
+      expect(mockChannel.publish).toHaveBeenCalledWith(
+        'openjob.events',
+        'application.created',
+        expect.any(Buffer),
+        expect.objectContaining({
+          headers: { 'x-retry-count': 2 },
+        }),
+      );
+      jest.useRealTimers();
+    });
+
+    it('should nack to DLQ after max retries (retryCount=3)', async () => {
+      prisma.client.application.findUnique.mockRejectedValueOnce(
+        new Error('Persistent failure'),
+      );
+      const msg = makeMessage({ applicationId: APPLICATION_UUID }, 3);
+
+      await service.processMessage(msg);
+
+      expect(mockChannel.nack).toHaveBeenCalledWith(msg, false, false);
+      expect(mockChannel.ack).not.toHaveBeenCalled();
+    });
+
+    it('should nack to DLQ when application is not found in DB', async () => {
+      jest.useFakeTimers();
+      prisma.client.application.findUnique.mockResolvedValueOnce(null);
+      const msg = makeMessage({ applicationId: APPLICATION_UUID }, 3);
+
+      const processPromise = service.processMessage(msg);
+      jest.runAllTimers();
+      await processPromise;
+
+      expect(mockChannel.nack).toHaveBeenCalledWith(msg, false, false);
+      jest.useRealTimers();
+    });
+  });
+});

--- a/src/modules/queue/notification.service.spec.ts
+++ b/src/modules/queue/notification.service.spec.ts
@@ -72,13 +72,16 @@ describe('NotificationService', () => {
 
   beforeEach(async () => {
     mockChannel = {
+      assertExchange: jest.fn().mockResolvedValue(undefined),
       assertQueue: jest.fn().mockResolvedValue(undefined),
+      bindQueue: jest.fn().mockResolvedValue(undefined),
       consume: jest.fn().mockResolvedValue(undefined),
       ack: jest.fn(),
       nack: jest.fn(),
       publish: jest.fn().mockReturnValue(true),
       close: jest.fn().mockResolvedValue(undefined),
       prefetch: jest.fn().mockResolvedValue(undefined),
+      on: jest.fn(),
     } as unknown as jest.Mocked<amqplib.Channel>;
 
     mockConnection = {

--- a/src/modules/queue/notification.service.spec.ts
+++ b/src/modules/queue/notification.service.spec.ts
@@ -258,15 +258,13 @@ describe('NotificationService', () => {
     });
 
     it('should ack and republish with incremented retry count on transient failure (retryCount=0)', async () => {
-      jest.useFakeTimers();
+      jest.spyOn(service as unknown as { delay: (ms: number) => Promise<void> }, 'delay').mockResolvedValue(undefined);
       prisma.client.application.findUnique.mockRejectedValueOnce(
         new Error('DB error'),
       );
       const msg = makeMessage({ applicationId: APPLICATION_UUID }, 0);
 
-      const processPromise = service.processMessage(msg);
-      jest.runAllTimers();
-      await processPromise;
+      await service.processMessage(msg);
 
       expect(mockChannel.ack).toHaveBeenCalledWith(msg);
       expect(mockChannel.publish).toHaveBeenCalledWith(
@@ -278,19 +276,16 @@ describe('NotificationService', () => {
           persistent: true,
         }),
       );
-      jest.useRealTimers();
     });
 
     it('should ack and republish with incremented retry count on transient failure (retryCount=1)', async () => {
-      jest.useFakeTimers();
+      jest.spyOn(service as unknown as { delay: (ms: number) => Promise<void> }, 'delay').mockResolvedValue(undefined);
       prisma.client.application.findUnique.mockRejectedValueOnce(
         new Error('DB error'),
       );
       const msg = makeMessage({ applicationId: APPLICATION_UUID }, 1);
 
-      const processPromise = service.processMessage(msg);
-      jest.runAllTimers();
-      await processPromise;
+      await service.processMessage(msg);
 
       expect(mockChannel.ack).toHaveBeenCalledWith(msg);
       expect(mockChannel.publish).toHaveBeenCalledWith(
@@ -301,7 +296,6 @@ describe('NotificationService', () => {
           headers: { 'x-retry-count': 2 },
         }),
       );
-      jest.useRealTimers();
     });
 
     it('should nack to DLQ after max retries (retryCount=3)', async () => {
@@ -317,16 +311,12 @@ describe('NotificationService', () => {
     });
 
     it('should nack to DLQ when application is not found in DB', async () => {
-      jest.useFakeTimers();
       prisma.client.application.findUnique.mockResolvedValueOnce(null);
       const msg = makeMessage({ applicationId: APPLICATION_UUID }, 3);
 
-      const processPromise = service.processMessage(msg);
-      jest.runAllTimers();
-      await processPromise;
+      await service.processMessage(msg);
 
       expect(mockChannel.nack).toHaveBeenCalledWith(msg, false, false);
-      jest.useRealTimers();
     });
   });
 });

--- a/src/modules/queue/notification.service.ts
+++ b/src/modules/queue/notification.service.ts
@@ -13,6 +13,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 
 const EXCHANGE_NAME = 'openjob.events';
 const QUEUE_NAME = 'application.created';
+const DLQ_NAME = 'application.created.dlq';
 const MAX_RETRIES = 3;
 
 type CompanyWithOwner = Company & { owner: User };
@@ -57,8 +58,28 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
       );
       this.channel = await this.connection.createChannel();
 
+      // Prevent unhandled 'error' events from crashing the process
+      this.channel.on('error', (err: Error) => {
+        this.logger.error(`Consumer channel error: ${err.message}`);
+      });
+
       // Process one message at a time
       await this.channel.prefetch(1);
+
+      // Assert full topology so the queue exists even when this consumer
+      // starts before QueueService (e.g. in a fresh CI environment)
+      await this.channel.assertExchange(EXCHANGE_NAME, 'direct', {
+        durable: true,
+      });
+      await this.channel.assertQueue(DLQ_NAME, { durable: true });
+      await this.channel.assertQueue(QUEUE_NAME, {
+        durable: true,
+        arguments: {
+          'x-dead-letter-exchange': '',
+          'x-dead-letter-routing-key': DLQ_NAME,
+        },
+      });
+      await this.channel.bindQueue(QUEUE_NAME, EXCHANGE_NAME, QUEUE_NAME);
 
       await this.channel.consume(QUEUE_NAME, (msg) => {
         if (msg) {

--- a/src/modules/queue/notification.service.ts
+++ b/src/modules/queue/notification.service.ts
@@ -1,0 +1,196 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as amqplib from 'amqplib';
+import * as nodemailer from 'nodemailer';
+import type { Application, Company, Job, User } from '@prisma/client';
+import type { EnvConfig } from '../../config/env.config';
+import { PrismaService } from '../../prisma/prisma.service';
+
+const EXCHANGE_NAME = 'openjob.events';
+const QUEUE_NAME = 'application.created';
+const MAX_RETRIES = 3;
+
+type CompanyWithOwner = Company & { owner: User };
+type JobWithCompany = Job & { company: CompanyWithOwner };
+type ApplicationWithRelations = Application & {
+  user: User;
+  job: JobWithCompany;
+};
+
+@Injectable()
+export class NotificationService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(NotificationService.name);
+  private connection: amqplib.ChannelModel | null = null;
+  private channel: amqplib.Channel | null = null;
+  private transporter: nodemailer.Transporter | null = null;
+
+  constructor(
+    private readonly config: ConfigService<EnvConfig, true>,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    this.transporter = nodemailer.createTransport({
+      host: this.config.get('MAIL_HOST'),
+      port: this.config.get('MAIL_PORT'),
+      auth: {
+        user: this.config.get('MAIL_USER'),
+        pass: this.config.get('MAIL_PASSWORD'),
+      },
+    });
+
+    try {
+      const host = this.config.get('RABBITMQ_HOST');
+      const port = this.config.get('RABBITMQ_PORT');
+      const user = this.config.get('RABBITMQ_USER');
+      const password = this.config.get('RABBITMQ_PASSWORD');
+
+      this.connection = await amqplib.connect(
+        `amqp://${user}:${password}@${host}:${port}`,
+      );
+      this.channel = await this.connection.createChannel();
+
+      // Process one message at a time
+      await this.channel.prefetch(1);
+
+      await this.channel.consume(QUEUE_NAME, (msg) => {
+        if (msg) {
+          void this.processMessage(msg);
+        }
+      });
+
+      this.logger.log('NotificationService consumer started');
+    } catch (err) {
+      this.logger.error(
+        `NotificationService failed to start: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    try {
+      await this.channel?.close();
+      await this.connection?.close();
+      this.logger.log('NotificationService consumer stopped');
+    } catch (err) {
+      this.logger.error(
+        `Error stopping NotificationService: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  async processMessage(msg: amqplib.Message): Promise<void> {
+    // --- Parse payload ---
+    let payload: { applicationId: string };
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const parsed = JSON.parse(msg.content.toString());
+      if (
+        !parsed ||
+        typeof parsed !== 'object' ||
+        typeof (parsed as Record<string, unknown>).applicationId !== 'string' ||
+        !(parsed as Record<string, unknown>).applicationId
+      ) {
+        throw new Error('Malformed payload: missing applicationId');
+      }
+      payload = parsed as { applicationId: string };
+    } catch (err) {
+      this.logger.error(
+        `Dead-lettering malformed message: ${(err as Error).message}`,
+      );
+      this.channel?.nack(msg, false, false);
+      return;
+    }
+
+    const retryCount = Number(
+      (msg.properties.headers?.['x-retry-count'] as number | undefined) ?? 0,
+    );
+
+    try {
+      const application = await this.prisma.client.application.findUnique({
+        where: { uuid: payload.applicationId },
+        include: {
+          user: true,
+          job: { include: { company: { include: { owner: true } } } },
+        },
+      });
+
+      if (!application) {
+        throw new Error(
+          `Application not found: ${payload.applicationId}`,
+        );
+      }
+
+      await this.sendNotificationEmail(
+        application as unknown as ApplicationWithRelations,
+      );
+
+      this.channel?.ack(msg);
+      this.logger.log(
+        `Notification sent for application ${payload.applicationId}`,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to process message (attempt ${retryCount + 1}): ${(err as Error).message}`,
+      );
+
+      if (retryCount < MAX_RETRIES) {
+        // Exponential backoff: 1s, 2s, 4s (2^retryCount * 1000ms)
+        const delay = Math.pow(2, retryCount) * 1000;
+        this.channel?.ack(msg);
+
+        await this.delay(delay);
+
+        const content = Buffer.from(JSON.stringify(payload));
+        this.channel?.publish(EXCHANGE_NAME, QUEUE_NAME, content, {
+          persistent: true,
+          contentType: 'application/json',
+          headers: { 'x-retry-count': retryCount + 1 },
+        });
+
+        this.logger.log(
+          `Scheduled retry ${retryCount + 1}/${MAX_RETRIES} for application ${payload.applicationId}`,
+        );
+      } else {
+        // Exhausted retries — dead-letter the message
+        this.channel?.nack(msg, false, false);
+        this.logger.warn(
+          `Max retries exceeded for application ${payload.applicationId}. Sending to DLQ.`,
+        );
+      }
+    }
+  }
+
+  async sendNotificationEmail(
+    application: ApplicationWithRelations,
+  ): Promise<void> {
+    const { user: applicant, job, createdAt } = application;
+    const ownerEmail = job.company.owner.email;
+    const applicationDate = createdAt.toISOString().split('T')[0];
+
+    await this.transporter!.sendMail({
+      from: this.config.get('MAIL_USER'),
+      to: ownerEmail,
+      subject: `New Application: ${job.title}`,
+      html: `
+        <h2>New Job Application Received</h2>
+        <p>A new candidate has applied for the position <strong>${job.title}</strong>.</p>
+        <table>
+          <tr><td><strong>Applicant Name:</strong></td><td>${applicant.fullname}</td></tr>
+          <tr><td><strong>Applicant Email:</strong></td><td>${applicant.email}</td></tr>
+          <tr><td><strong>Application Date:</strong></td><td>${applicationDate}</td></tr>
+        </table>
+        <p>Log in to OpenJob to review and update the application status.</p>
+      `,
+    });
+  }
+
+  protected delay(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/src/modules/queue/notification.service.ts
+++ b/src/modules/queue/notification.service.ts
@@ -35,9 +35,11 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
   ) {}
 
   async onModuleInit(): Promise<void> {
+    const mailPort = this.config.get('MAIL_PORT');
     this.transporter = nodemailer.createTransport({
       host: this.config.get('MAIL_HOST'),
-      port: this.config.get('MAIL_PORT'),
+      port: mailPort,
+      secure: mailPort === 465, // SSL for port 465, STARTTLS for 587
       auth: {
         user: this.config.get('MAIL_USER'),
         pass: this.config.get('MAIL_PASSWORD'),

--- a/src/modules/queue/notification.service.ts
+++ b/src/modules/queue/notification.service.ts
@@ -35,22 +35,22 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
   ) {}
 
   async onModuleInit(): Promise<void> {
-    const mailPort = this.config.get('MAIL_PORT');
+    const mailPort: number = this.config.get('MAIL_PORT');
+    const mailHost: string = this.config.get('MAIL_HOST');
+    const mailUser: string = this.config.get('MAIL_USER');
+    const mailPass: string = this.config.get('MAIL_PASSWORD');
     this.transporter = nodemailer.createTransport({
-      host: this.config.get('MAIL_HOST'),
+      host: mailHost,
       port: mailPort,
       secure: mailPort === 465, // SSL for port 465, STARTTLS for 587
-      auth: {
-        user: this.config.get('MAIL_USER'),
-        pass: this.config.get('MAIL_PASSWORD'),
-      },
+      auth: { user: mailUser, pass: mailPass },
     });
 
     try {
-      const host = this.config.get('RABBITMQ_HOST');
-      const port = this.config.get('RABBITMQ_PORT');
-      const user = this.config.get('RABBITMQ_USER');
-      const password = this.config.get('RABBITMQ_PASSWORD');
+      const host: string = this.config.get('RABBITMQ_HOST');
+      const port: number = this.config.get('RABBITMQ_PORT');
+      const user: string = this.config.get('RABBITMQ_USER');
+      const password: string = this.config.get('RABBITMQ_PASSWORD');
 
       this.connection = await amqplib.connect(
         `amqp://${user}:${password}@${host}:${port}`,
@@ -123,14 +123,10 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
       });
 
       if (!application) {
-        throw new Error(
-          `Application not found: ${payload.applicationId}`,
-        );
+        throw new Error(`Application not found: ${payload.applicationId}`);
       }
 
-      await this.sendNotificationEmail(
-        application as unknown as ApplicationWithRelations,
-      );
+      await this.sendNotificationEmail(application);
 
       this.channel?.ack(msg);
       this.logger.log(
@@ -175,8 +171,9 @@ export class NotificationService implements OnModuleInit, OnModuleDestroy {
     const ownerEmail = job.company.owner.email;
     const applicationDate = createdAt.toISOString().split('T')[0];
 
+    const from: string = this.config.get('MAIL_USER');
     await this.transporter!.sendMail({
-      from: this.config.get('MAIL_USER'),
+      from,
       to: ownerEmail,
       subject: `New Application: ${job.title}`,
       html: `

--- a/src/modules/queue/queue.module.ts
+++ b/src/modules/queue/queue.module.ts
@@ -1,9 +1,12 @@
 import { Global, Module } from '@nestjs/common';
 import { QueueService } from './queue.service';
+import { NotificationService } from './notification.service';
+import { PrismaModule } from '../../prisma/prisma.module';
 
 @Global()
 @Module({
-  providers: [QueueService],
+  imports: [PrismaModule],
+  providers: [QueueService, NotificationService],
   exports: [QueueService],
 })
 export class QueueModule {}

--- a/src/modules/queue/queue.service.spec.ts
+++ b/src/modules/queue/queue.service.spec.ts
@@ -1,0 +1,146 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import * as amqplib from 'amqplib';
+import { QueueService } from './queue.service';
+
+jest.mock('amqplib');
+
+const EXCHANGE_NAME = 'openjob.events';
+const QUEUE_NAME = 'application.created';
+const DLQ_NAME = 'application.created.dlq';
+
+describe('QueueService', () => {
+  let service: QueueService;
+  let mockChannel: jest.Mocked<amqplib.Channel>;
+  let mockConnection: jest.Mocked<amqplib.ChannelModel>;
+
+  beforeEach(async () => {
+    mockChannel = {
+      assertExchange: jest.fn().mockResolvedValue(undefined),
+      assertQueue: jest.fn().mockResolvedValue(undefined),
+      bindQueue: jest.fn().mockResolvedValue(undefined),
+      publish: jest.fn().mockReturnValue(true),
+      close: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<amqplib.Channel>;
+
+    mockConnection = {
+      createChannel: jest.fn().mockResolvedValue(mockChannel),
+      close: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<amqplib.ChannelModel>;
+
+    (amqplib.connect as jest.Mock).mockResolvedValue(mockConnection);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueueService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              const config: Record<string, string | number> = {
+                RABBITMQ_HOST: 'localhost',
+                RABBITMQ_PORT: 5672,
+                RABBITMQ_USER: 'guest',
+                RABBITMQ_PASSWORD: 'guest',
+              };
+              return config[key];
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<QueueService>(QueueService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('onModuleInit', () => {
+    it('should connect to RabbitMQ and assert exchange', async () => {
+      await service.onModuleInit();
+
+      expect(amqplib.connect).toHaveBeenCalledWith(
+        'amqp://guest:guest@localhost:5672',
+      );
+      expect(mockChannel.assertExchange).toHaveBeenCalledWith(
+        EXCHANGE_NAME,
+        'direct',
+        { durable: true },
+      );
+    });
+
+    it('should assert the DLQ as a durable queue', async () => {
+      await service.onModuleInit();
+
+      expect(mockChannel.assertQueue).toHaveBeenCalledWith(DLQ_NAME, {
+        durable: true,
+      });
+    });
+
+    it('should assert the main queue with dead-letter routing to DLQ', async () => {
+      await service.onModuleInit();
+
+      expect(mockChannel.assertQueue).toHaveBeenCalledWith(QUEUE_NAME, {
+        durable: true,
+        arguments: {
+          'x-dead-letter-exchange': '',
+          'x-dead-letter-routing-key': DLQ_NAME,
+        },
+      });
+    });
+
+    it('should bind the main queue to the exchange with the correct routing key', async () => {
+      await service.onModuleInit();
+
+      expect(mockChannel.bindQueue).toHaveBeenCalledWith(
+        QUEUE_NAME,
+        EXCHANGE_NAME,
+        QUEUE_NAME,
+      );
+    });
+
+    it('should log a warning and not throw if connection fails', async () => {
+      (amqplib.connect as jest.Mock).mockRejectedValue(
+        new Error('Connection refused'),
+      );
+
+      await expect(service.onModuleInit()).resolves.not.toThrow();
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('should close channel and connection on destroy', async () => {
+      await service.onModuleInit();
+      await service.onModuleDestroy();
+
+      expect(mockChannel.close).toHaveBeenCalled();
+      expect(mockConnection.close).toHaveBeenCalled();
+    });
+
+    it('should not throw if connection was never established', async () => {
+      await expect(service.onModuleDestroy()).resolves.not.toThrow();
+    });
+  });
+
+  describe('publish', () => {
+    it('should publish a JSON-encoded message to the exchange', async () => {
+      await service.onModuleInit();
+      const payload = { applicationId: 'abc-123' };
+
+      service.publish(QUEUE_NAME, payload);
+
+      expect(mockChannel.publish).toHaveBeenCalledWith(
+        EXCHANGE_NAME,
+        QUEUE_NAME,
+        Buffer.from(JSON.stringify(payload)),
+        { persistent: true, contentType: 'application/json' },
+      );
+    });
+
+    it('should log a warning and not throw if channel is not available', () => {
+      expect(() => service.publish(QUEUE_NAME, { applicationId: 'x' })).not.toThrow();
+    });
+  });
+});

--- a/src/modules/queue/queue.service.ts
+++ b/src/modules/queue/queue.service.ts
@@ -10,6 +10,8 @@ import type { EnvConfig } from '../../config/env.config';
 
 const EXCHANGE_NAME = 'openjob.events';
 const EXCHANGE_TYPE = 'direct';
+const QUEUE_NAME = 'application.created';
+const DLQ_NAME = 'application.created.dlq';
 
 @Injectable()
 export class QueueService implements OnModuleInit, OnModuleDestroy {
@@ -34,6 +36,21 @@ export class QueueService implements OnModuleInit, OnModuleDestroy {
       await this.channel.assertExchange(EXCHANGE_NAME, EXCHANGE_TYPE, {
         durable: true,
       });
+
+      // Assert DLQ first — no dead-letter, simply durable
+      await this.channel.assertQueue(DLQ_NAME, { durable: true });
+
+      // Assert main queue with dead-letter routing to DLQ
+      await this.channel.assertQueue(QUEUE_NAME, {
+        durable: true,
+        arguments: {
+          'x-dead-letter-exchange': '',
+          'x-dead-letter-routing-key': DLQ_NAME,
+        },
+      });
+
+      // Bind main queue to the exchange using the routing key
+      await this.channel.bindQueue(QUEUE_NAME, EXCHANGE_NAME, QUEUE_NAME);
 
       this.logger.log('RabbitMQ connection established');
     } catch (err) {

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -1,6 +1,3 @@
-// OpenJob API - Prisma Schema
-// See: docs/database-design.md
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -10,114 +7,85 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// =====================================================================
-// USERS
-// =====================================================================
-
 model User {
-  id        Int       @id @default(autoincrement())
-  uuid      String    @unique @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  fullname  String    @db.VarChar(100)
-  email     String    @unique @db.VarChar(150)
-  password  String    @db.Text
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
-  deletedAt DateTime? @map("deleted_at") @db.Timestamptz()
-
-  authentications Authentication[]
-  companies       Company[]
+  id              Int              @id @default(autoincrement())
+  uuid            String           @unique @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  fullname        String           @db.VarChar(100)
+  email           String           @unique @db.VarChar(150)
+  password        String
+  createdAt       DateTime         @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt       DateTime         @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt       DateTime?        @map("deleted_at") @db.Timestamptz(6)
   applications    Application[]
+  authentications Authentication[]
   bookmarks       Bookmark[]
+  companies       Company[]
   documents       Document[]
 
   @@map("users")
 }
 
-// =====================================================================
-// AUTHENTICATIONS (Refresh Tokens)
-// =====================================================================
-
 model Authentication {
-  token     String   @id @db.Text
+  token     String   @id
   userId    Int      @map("user_id")
-  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@map("authentications")
 }
 
-// =====================================================================
-// COMPANIES
-// =====================================================================
-
 model Company {
   id          Int       @id @default(autoincrement())
   uuid        String    @unique @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   name        String    @db.VarChar(150)
-  description String    @db.Text
+  description String
   location    String    @db.VarChar(150)
   userId      Int       @map("user_id")
-  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
-  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz()
-
-  owner User  @relation(fields: [userId], references: [id])
-  jobs  Job[]
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz(6)
+  owner       User      @relation(fields: [userId], references: [id])
+  jobs        Job[]
 
   @@index([userId])
   @@map("companies")
 }
 
-// =====================================================================
-// CATEGORIES
-// =====================================================================
-
 model Category {
   id        Int       @id @default(autoincrement())
   uuid      String    @unique @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   name      String    @unique @db.VarChar(100)
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
-  deletedAt DateTime? @map("deleted_at") @db.Timestamptz()
-
-  jobs Job[]
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6)
+  jobs      Job[]
 
   @@map("categories")
 }
 
-// =====================================================================
-// JOBS
-// =====================================================================
-
 model Job {
-  id          Int       @id @default(autoincrement())
-  uuid        String    @unique @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  companyId   Int       @map("company_id")
-  categoryId  Int       @map("category_id")
-  title       String    @db.VarChar(200)
-  description String    @db.Text
-  location    String    @db.VarChar(150)
-  salary      Decimal?  @db.Decimal(15, 2)
-  type        String    @db.VarChar(50)
-  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt   DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
-  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz()
-
-  company      Company       @relation(fields: [companyId], references: [id])
-  category     Category      @relation(fields: [categoryId], references: [id])
+  id           Int           @id @default(autoincrement())
+  uuid         String        @unique @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  companyId    Int           @map("company_id")
+  categoryId   Int           @map("category_id")
+  title        String        @db.VarChar(200)
+  description  String
+  location     String        @db.VarChar(150)
+  salary       Decimal?      @db.Decimal(15, 2)
+  type         String        @db.VarChar(50)
+  createdAt    DateTime      @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt    DateTime      @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt    DateTime?     @map("deleted_at") @db.Timestamptz(6)
   applications Application[]
   bookmarks    Bookmark[]
+  category     Category      @relation(fields: [categoryId], references: [id])
+  company      Company       @relation(fields: [companyId], references: [id])
 
   @@index([companyId])
   @@index([categoryId])
   @@map("jobs")
 }
-
-// =====================================================================
-// APPLICATIONS
-// =====================================================================
 
 model Application {
   id        Int       @id @default(autoincrement())
@@ -125,12 +93,11 @@ model Application {
   userId    Int       @map("user_id")
   jobId     Int       @map("job_id")
   status    String    @default("pending") @db.VarChar(30)
-  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz()
-  deletedAt DateTime? @map("deleted_at") @db.Timestamptz()
-
-  user User @relation(fields: [userId], references: [id])
-  job  Job  @relation(fields: [jobId], references: [id])
+  createdAt DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime  @updatedAt @map("updated_at") @db.Timestamptz(6)
+  deletedAt DateTime? @map("deleted_at") @db.Timestamptz(6)
+  job       Job       @relation(fields: [jobId], references: [id])
+  user      User      @relation(fields: [userId], references: [id])
 
   @@unique([userId, jobId], name: "applications_user_id_job_id_key")
   @@index([userId])
@@ -138,30 +105,21 @@ model Application {
   @@map("applications")
 }
 
-// =====================================================================
-// BOOKMARKS
-// =====================================================================
-
 model Bookmark {
   id        Int      @id @default(autoincrement())
   uuid      String   @unique @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   userId    Int      @map("user_id")
   jobId     Int      @map("job_id")
-  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz()
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-  job  Job  @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+  job       Job      @relation(fields: [jobId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, jobId], name: "bookmarks_user_id_job_id_key")
   @@index([userId])
   @@index([jobId])
   @@map("bookmarks")
 }
-
-// =====================================================================
-// DOCUMENTS
-// =====================================================================
 
 model Document {
   id           Int      @id @default(autoincrement())
@@ -172,10 +130,9 @@ model Document {
   mimeType     String   @map("mime_type") @db.VarChar(100)
   size         Int
   url          String   @db.VarChar(500)
-  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz()
-  updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamptz()
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt    DateTime @updatedAt @map("updated_at") @db.Timestamptz(6)
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
   @@map("documents")

--- a/test/e2e/queue.e2e-spec.ts
+++ b/test/e2e/queue.e2e-spec.ts
@@ -284,11 +284,12 @@ describe('Queue – Consumer / NotificationService (e2e)', () => {
     notificationService['channel'] = mockChannel as unknown as amqplib.Channel;
 
     // ── Seed: owner → company + category → job → applicant → application ─────
-    const ownerEmail = `e2e_owner_${rand()}@example.com`;
+    // The notification email goes to the job OWNER — set it to a real inbox for manual verification
+    const ownerEmail = 'gilangheavy@gmail.com';
     const applicantEmail = `e2e_applicant_${rand()}@example.com`;
 
     const owner = await prisma.client.user.create({
-      data: { fullname: 'E2E Job Owner', email: ownerEmail, password: 'hashed' },
+      data: { fullname: 'E2E Job Owner (Gilang)', email: ownerEmail, password: 'hashed' },
     });
 
     const applicant = await prisma.client.user.create({

--- a/test/e2e/queue.e2e-spec.ts
+++ b/test/e2e/queue.e2e-spec.ts
@@ -1,0 +1,420 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { ThrottlerStorage } from '@nestjs/throttler';
+import type * as amqplib from 'amqplib';
+import { AppModule } from '../../src/app.module';
+import { PrismaModule } from '../../src/prisma/prisma.module';
+import { PrismaService } from '../../src/prisma/prisma.service';
+import { CacheService } from '../../src/modules/cache/cache.service';
+import { QueueService } from '../../src/modules/queue/queue.service';
+import { NotificationService } from '../../src/modules/queue/notification.service';
+import { AllExceptionsFilter } from '../../src/common/filters/all-exceptions.filter';
+import { validate } from '../../src/config/env.config';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const rand = () => Math.random().toString(36).substring(7);
+const makeUser = () => ({
+  fullname: `User ${rand()}`,
+  email: `user_${rand()}@example.com`,
+  password: 'StrongPassword123!',
+});
+
+async function registerAndLogin(
+  app: INestApplication<App>,
+): Promise<{ token: string; email: string; password: string }> {
+  const user = makeUser();
+  await request(app.getHttpServer()).post('/api/v1/users').send(user).expect(201);
+
+  const res = await request(app.getHttpServer())
+    .post('/api/v1/authentications')
+    .send({ email: user.email, password: user.password })
+    .expect(201);
+
+  return {
+    token: res.body.data.accessToken as string,
+    email: user.email,
+    password: user.password,
+  };
+}
+
+async function setupOwnerWithJob(app: INestApplication<App>): Promise<{
+  ownerToken: string;
+  jobId: string;
+}> {
+  const { token: ownerToken } = await registerAndLogin(app);
+
+  const companyRes = await request(app.getHttpServer())
+    .post('/api/v1/companies')
+    .set('Authorization', `Bearer ${ownerToken}`)
+    .send({ name: `Company ${rand()}`, description: 'Test', location: 'Jakarta' })
+    .expect(201);
+
+  const categoryRes = await request(app.getHttpServer())
+    .post('/api/v1/categories')
+    .set('Authorization', `Bearer ${ownerToken}`)
+    .send({ name: `Category ${rand()}` })
+    .expect(201);
+
+  const jobRes = await request(app.getHttpServer())
+    .post('/api/v1/jobs')
+    .set('Authorization', `Bearer ${ownerToken}`)
+    .send({
+      companyId: companyRes.body.data.id as string,
+      categoryId: categoryRes.body.data.id as string,
+      title: `Engineer ${rand()}`,
+      description: 'Build things',
+      location: 'Remote',
+      salary: 10000000,
+      type: 'Full-time',
+    })
+    .expect(201);
+
+  return { ownerToken, jobId: jobRes.body.data.id as string };
+}
+
+const throttlerMock = {
+  increment: jest.fn().mockResolvedValue({
+    totalHits: 0,
+    timeToExpire: 9999,
+    isBlocked: false,
+    timeToBlockExpire: 0,
+  }),
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PART 1: Producer — POST /applications fires the application:created event
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Queue – Producer (e2e)', () => {
+  let app: INestApplication<App>;
+  let prisma: PrismaService;
+  let cache: CacheService;
+  let mockPublish: jest.Mock;
+
+  beforeAll(async () => {
+    mockPublish = jest.fn();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(ThrottlerStorage)
+      .useValue(throttlerMock)
+      .overrideProvider(QueueService)
+      .useValue({
+        publish: mockPublish,
+        onModuleInit: jest.fn(),
+        onModuleDestroy: jest.fn(),
+      })
+      .overrideProvider(NotificationService)
+      .useValue({ onModuleInit: jest.fn(), onModuleDestroy: jest.fn() })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api/v1');
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
+    );
+    app.useGlobalFilters(new AllExceptionsFilter());
+
+    prisma = moduleFixture.get(PrismaService);
+    cache = moduleFixture.get(CacheService);
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await prisma.$executeRaw`DELETE FROM applications`;
+    await prisma.client.job.deleteMany({});
+    await prisma.client.category.deleteMany({});
+    await prisma.client.company.deleteMany({});
+    await prisma.client.authentication.deleteMany({});
+    await prisma.client.user.deleteMany({});
+    await app.close();
+  });
+
+  afterEach(async () => {
+    await prisma.$executeRaw`DELETE FROM applications`;
+    await prisma.client.job.deleteMany({});
+    await prisma.client.category.deleteMany({});
+    await prisma.client.company.deleteMany({});
+    await prisma.client.authentication.deleteMany({});
+    await prisma.client.user.deleteMany({});
+    await cache.del('applications:*');
+    mockPublish.mockClear();
+  });
+
+  it('should publish application.created event with the correct applicationId', async () => {
+    const { jobId } = await setupOwnerWithJob(app);
+    const { token } = await registerAndLogin(app);
+
+    const res = await request(app.getHttpServer())
+      .post('/api/v1/applications')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ jobId })
+      .expect(201);
+
+    const applicationId = res.body.data.id as string;
+
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(mockPublish).toHaveBeenCalledWith('application.created', {
+      applicationId,
+    });
+  });
+
+  it('should NOT publish event when application creation fails (duplicate)', async () => {
+    const { jobId } = await setupOwnerWithJob(app);
+    const { token } = await registerAndLogin(app);
+
+    await request(app.getHttpServer())
+      .post('/api/v1/applications')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ jobId })
+      .expect(201);
+
+    mockPublish.mockClear();
+
+    await request(app.getHttpServer())
+      .post('/api/v1/applications')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ jobId })
+      .expect(409);
+
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it('should NOT publish event when owner applies to their own job (403)', async () => {
+    const { ownerToken, jobId } = await setupOwnerWithJob(app);
+
+    await request(app.getHttpServer())
+      .post('/api/v1/applications')
+      .set('Authorization', `Bearer ${ownerToken}`)
+      .send({ jobId })
+      .expect(403);
+
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it('should return 201 immediately without waiting for RabbitMQ (fire-and-forget)', async () => {
+    const { jobId } = await setupOwnerWithJob(app);
+    const { token } = await registerAndLogin(app);
+
+    const start = Date.now();
+    await request(app.getHttpServer())
+      .post('/api/v1/applications')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ jobId })
+      .expect(201);
+
+    // Must complete well under 3s — not waiting on RabbitMQ
+    expect(Date.now() - start).toBeLessThan(3000);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PART 2: Consumer — NotificationService sends a real email via SMTP
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Queue – Consumer / NotificationService (e2e)', () => {
+  let nestModule: TestingModule;
+  let notificationService: NotificationService;
+  let prisma: PrismaService;
+
+  let mockChannel: {
+    ack: jest.Mock;
+    nack: jest.Mock;
+    publish: jest.Mock;
+    close: jest.Mock;
+  };
+
+  // UUID of a real application seeded into the DB
+  let applicationUuid: string;
+
+  function buildMsg(
+    payload: unknown,
+    retryCount = 0,
+  ): amqplib.Message {
+    return {
+      content: Buffer.from(JSON.stringify(payload)),
+      properties: {
+        headers: { 'x-retry-count': retryCount },
+        contentType: 'application/json',
+        deliveryMode: 2,
+        persistent: true,
+      },
+      fields: {
+        deliveryTag: 1,
+        exchange: 'openjob.events',
+        routingKey: 'application.created',
+        redelivered: false,
+        consumerTag: 'test-consumer',
+      },
+    } as unknown as amqplib.Message;
+  }
+
+  beforeAll(async () => {
+    // Minimal module: ConfigService (reads .env) + Prisma + NotificationService
+    // NotificationService.onModuleInit() will try RabbitMQ — fails gracefully,
+    // then we inject a mock channel for the processMessage tests.
+    nestModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, validate }),
+        PrismaModule,
+      ],
+      providers: [NotificationService],
+    }).compile();
+
+    notificationService = nestModule.get(NotificationService);
+    prisma = nestModule.get(PrismaService);
+
+    await nestModule.init();
+
+    // Override channel with mock (RabbitMQ may or may not be running)
+    mockChannel = {
+      ack: jest.fn(),
+      nack: jest.fn(),
+      publish: jest.fn().mockReturnValue(true),
+      close: jest.fn().mockResolvedValue(undefined),
+    };
+    notificationService['channel'] = mockChannel as unknown as amqplib.Channel;
+
+    // ── Seed: owner → company + category → job → applicant → application ─────
+    const ownerEmail = `e2e_owner_${rand()}@example.com`;
+    const applicantEmail = `e2e_applicant_${rand()}@example.com`;
+
+    const owner = await prisma.client.user.create({
+      data: { fullname: 'E2E Job Owner', email: ownerEmail, password: 'hashed' },
+    });
+
+    const applicant = await prisma.client.user.create({
+      data: { fullname: 'E2E Applicant Budi', email: applicantEmail, password: 'hashed' },
+    });
+
+    const company = await prisma.client.company.create({
+      data: {
+        name: `E2E Company ${rand()}`,
+        description: 'Test company',
+        location: 'Jakarta',
+        userId: owner.id,
+      },
+    });
+
+    const category = await prisma.client.category.create({
+      data: { name: `E2E Category ${rand()}` },
+    });
+
+    const job = await prisma.client.job.create({
+      data: {
+        title: 'E2E Software Engineer',
+        description: 'Build things',
+        location: 'Remote',
+        type: 'Full-time',
+        companyId: company.id,
+        categoryId: category.id,
+      },
+    });
+
+    const application = await prisma.client.application.create({
+      data: { userId: applicant.id, jobId: job.id },
+    });
+
+    applicationUuid = application.uuid;
+  });
+
+  afterAll(async () => {
+    await prisma.$executeRaw`DELETE FROM applications`;
+    await prisma.$executeRaw`DELETE FROM jobs`;
+    await prisma.$executeRaw`DELETE FROM categories`;
+    await prisma.$executeRaw`DELETE FROM companies`;
+    await prisma.$executeRaw`DELETE FROM users`;
+    await nestModule.close();
+  });
+
+  afterEach(() => {
+    mockChannel.ack.mockClear();
+    mockChannel.nack.mockClear();
+    mockChannel.publish.mockClear();
+    // Re-inject mock channel in case it was replaced
+    notificationService['channel'] = mockChannel as unknown as amqplib.Channel;
+  });
+
+  // ── Happy path — real SMTP email ────────────────────────────────────────────
+
+  it('should send email to job owner and ack the message', async () => {
+    const msg = buildMsg({ applicationId: applicationUuid });
+
+    await notificationService.processMessage(msg);
+
+    expect(mockChannel.ack).toHaveBeenCalledWith(msg);
+    expect(mockChannel.nack).not.toHaveBeenCalled();
+  }, 15_000); // Allow time for real SMTP
+
+  // ── Malformed messages ──────────────────────────────────────────────────────
+
+  it('should nack malformed JSON immediately without retry', async () => {
+    const msg = {
+      content: Buffer.from('not-valid-json{{{'),
+      properties: { headers: {} },
+      fields: {
+        deliveryTag: 2,
+        exchange: '',
+        routingKey: '',
+        redelivered: false,
+        consumerTag: '',
+      },
+    } as unknown as amqplib.Message;
+
+    await notificationService.processMessage(msg);
+
+    expect(mockChannel.nack).toHaveBeenCalledWith(msg, false, false);
+    expect(mockChannel.ack).not.toHaveBeenCalled();
+  });
+
+  it('should nack message missing applicationId field without retry', async () => {
+    const msg = buildMsg({ wrongField: 'abc' });
+
+    await notificationService.processMessage(msg);
+
+    expect(mockChannel.nack).toHaveBeenCalledWith(msg, false, false);
+    expect(mockChannel.ack).not.toHaveBeenCalled();
+  });
+
+  // ── DLQ ────────────────────────────────────────────────────────────────────
+
+  it('should nack to DLQ when retryCount is already at max (3)', async () => {
+    // Use a UUID that does not exist in DB — triggers error path
+    const msg = buildMsg({ applicationId: '00000000-0000-0000-0000-000000000000' }, 3);
+
+    await notificationService.processMessage(msg);
+
+    expect(mockChannel.nack).toHaveBeenCalledWith(msg, false, false);
+    expect(mockChannel.ack).not.toHaveBeenCalled();
+  });
+
+  it('should ack and schedule retry when retryCount < 3 and processing fails', async () => {
+    jest
+      .spyOn(
+        notificationService as unknown as { delay: (ms: number) => Promise<void> },
+        'delay',
+      )
+      .mockResolvedValue(undefined);
+
+    // Non-existent application UUID with retryCount=0 → ack + republish with count=1
+    const msg = buildMsg({ applicationId: '00000000-0000-0000-0000-000000000001' }, 0);
+
+    await notificationService.processMessage(msg);
+
+    expect(mockChannel.ack).toHaveBeenCalledWith(msg);
+    expect(mockChannel.publish).toHaveBeenCalledWith(
+      'openjob.events',
+      'application.created',
+      expect.any(Buffer),
+      expect.objectContaining({ headers: { 'x-retry-count': 1 } }),
+    );
+  });
+});


### PR DESCRIPTION
## 📋 Description

Implements the complete asynchronous notification pipeline for job applications:

1. **Issue #16 — RabbitMQ Producer**: `QueueService` now declares the `application.created` queue (durable, with dead-letter config) and `application.created.dlq`, bound to the `openjob.events` exchange. The existing fire-and-forget `publish()` in `POST /applications` remains unblocking.

2. **Issue #17 — RabbitMQ Consumer + Nodemailer**: New `NotificationService` that consumes messages from `application.created`, queries the DB for applicant/owner details, and sends an email notification to the **job owner** via Nodemailer SMTP.

---

## ✅ Changes

### `QueueService` (closes #16)
- Assert `application.created.dlq` (durable)
- Assert `application.created` queue (durable) with `x-dead-letter-exchange` → default exchange and `x-dead-letter-routing-key` → `application.created.dlq`
- Bind `application.created` queue to `openjob.events` exchange

### `NotificationService` (closes #17)
- Consumes from `application.created` with `prefetch(1)` for sequential processing
- On message: queries DB (`applicationId`) → fetches applicant name, email, date, and job owner email
- Sends email to **job owner** containing applicant name, email, application date
- **Retry policy**: max 3x, exponential backoff `1s → 2s → 4s` via `ack` + delayed republish with `x-retry-count` header
- After max retries: `nack(false, false)` → routes to `application.created.dlq`
- Malformed / unparseable messages → immediately dead-lettered (no retry)
- Consumer failure never crashes the API

### `QueueModule`
- Registers `NotificationService` as a provider
- Imports `PrismaModule` for DB access in the consumer

### Dependencies
- `nodemailer` + `@types/nodemailer`

---

## 🧪 Tests

| File | Tests |
|---|---|
| `queue.service.spec.ts` | 9 tests — exchange, queue, DLQ assertion, binding, publish, error handling |
| `notification.service.spec.ts` | 12 tests — consumer start, ack/send, malformed nack, retry (0,1), max-retry DLQ, email content/recipient |

All 331 tests pass ✅

---

## 🔗 Closes

- Closes #16
- Closes #17
