### PR TITLE
feat: integrate Swagger / OpenAPI documentation (closes #18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.4.2",
         "@nestjs/terminus": "^11.1.1",
         "@nestjs/throttler": "^6.5.0",
         "@prisma/client": "^6.19.3",
@@ -2968,6 +2969,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -3297,6 +3304,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.19",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.19.tgz",
@@ -3337,6 +3364,39 @@
       },
       "peerDependenciesMeta": {
         "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.2.tgz",
+      "integrity": "sha512-aBihEogDMj/bLEcaqhkvyX/ZVWUw/bmnhKzR0zwUoyGJikvZyaq7rOPYl/H7Lxkkr3c90SJxyuv1AX2UT1WKlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.4"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }
@@ -3609,6 +3669,13 @@
       "dependencies": {
         "@prisma/debug": "6.19.3"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.49",
@@ -5754,7 +5821,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -9363,7 +9429,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11393,6 +11458,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.4.2",
     "@nestjs/terminus": "^11.1.1",
     "@nestjs/throttler": "^6.5.0",
     "@prisma/client": "^6.19.3",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 import { CorrelationIdInterceptor } from './common/interceptors/correlation-id.interceptor';
@@ -19,6 +20,23 @@ async function bootstrap() {
 
   app.useGlobalFilters(new AllExceptionsFilter());
   app.useGlobalInterceptors(new CorrelationIdInterceptor());
+
+  const config = new DocumentBuilder()
+    .setTitle('OpenJob API')
+    .setDescription(
+      'Enterprise-scale RESTful API for managing internal recruitment processes.',
+    )
+    .setVersion('1.0')
+    .addBearerAuth(
+      { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+      'access-token',
+    )
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document, {
+    swaggerOptions: { persistAuthorization: true },
+  });
 
   await app.listen(process.env.PORT ?? 5000);
 }

--- a/src/modules/applications/applications.controller.ts
+++ b/src/modules/applications/applications.controller.ts
@@ -12,6 +12,15 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiHeader,
+} from '@nestjs/swagger';
 import type { Response } from 'express';
 import { ApplicationsService } from './applications.service';
 import { CreateApplicationDto } from './dto/create-application.dto';
@@ -26,13 +35,19 @@ import {
   type PaginatedResult,
 } from '../profile/dto/pagination-query.dto';
 
+@ApiTags('Applications')
+@ApiBearerAuth('access-token')
+@UseGuards(JwtAuthGuard)
 @Controller('applications')
 export class ApplicationsController {
   constructor(private readonly applicationsService: ApplicationsService) {}
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Submit a job application' })
+  @ApiResponse({ status: 201, description: 'Application created', type: ApplicationResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 409, description: 'Already applied to this job' })
   create(
     @CurrentUser() user: JwtPayload,
     @Body() dto: CreateApplicationDto,
@@ -41,7 +56,10 @@ export class ApplicationsController {
   }
 
   @Get()
-  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'List all applications (admin, paginated)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated list of applications' })
   getAll(
     @Query() query: PaginationQueryDto,
   ): Promise<PaginatedResult<ApplicationResponseDto>> {
@@ -49,7 +67,13 @@ export class ApplicationsController {
   }
 
   @Get('user/:userId')
-  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'List applications by user UUID' })
+  @ApiParam({ name: 'userId', description: 'User UUID' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiHeader({ name: 'X-Data-Source', required: false, description: 'cache | database' })
+  @ApiResponse({ status: 200, description: 'Paginated list of applications for the user' })
+  @ApiResponse({ status: 403, description: 'Forbidden — cannot view another user\'s applications' })
   async getByUser(
     @Param('userId') userId: string,
     @CurrentUser() user: JwtPayload,
@@ -66,7 +90,13 @@ export class ApplicationsController {
   }
 
   @Get('job/:jobId')
-  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'List applications for a job (company owner only)' })
+  @ApiParam({ name: 'jobId', description: 'Job UUID' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiHeader({ name: 'X-Data-Source', required: false, description: 'cache | database' })
+  @ApiResponse({ status: 200, description: 'Paginated list of applications for the job' })
+  @ApiResponse({ status: 403, description: 'Forbidden — not the job owner' })
   async getByJob(
     @Param('jobId') jobId: string,
     @CurrentUser() user: JwtPayload,
@@ -83,7 +113,11 @@ export class ApplicationsController {
   }
 
   @Get(':uuid')
-  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get a single application by UUID' })
+  @ApiParam({ name: 'uuid', description: 'Application UUID' })
+  @ApiHeader({ name: 'X-Data-Source', required: false, description: 'cache | database' })
+  @ApiResponse({ status: 200, description: 'Application found', type: ApplicationResponseDto })
+  @ApiResponse({ status: 404, description: 'Application not found' })
   async getById(
     @Param('uuid') uuid: string,
     @CurrentUser() user: JwtPayload,
@@ -99,8 +133,12 @@ export class ApplicationsController {
 
   @Put(':uuid')
   @HttpCode(HttpStatus.OK)
-  @UseGuards(JwtAuthGuard)
   @SkipTransform()
+  @ApiOperation({ summary: 'Update application status (company owner only)' })
+  @ApiParam({ name: 'uuid', description: 'Application UUID' })
+  @ApiResponse({ status: 200, description: 'Application status updated successfully' })
+  @ApiResponse({ status: 403, description: 'Forbidden — not the job owner' })
+  @ApiResponse({ status: 404, description: 'Application not found' })
   async updateStatus(
     @Param('uuid') uuid: string,
     @CurrentUser() user: JwtPayload,
@@ -115,8 +153,12 @@ export class ApplicationsController {
 
   @Delete(':uuid')
   @HttpCode(HttpStatus.OK)
-  @UseGuards(JwtAuthGuard)
   @SkipTransform()
+  @ApiOperation({ summary: 'Withdraw (soft-delete) a job application' })
+  @ApiParam({ name: 'uuid', description: 'Application UUID' })
+  @ApiResponse({ status: 200, description: 'Application deleted successfully' })
+  @ApiResponse({ status: 403, description: 'Forbidden — not the applicant' })
+  @ApiResponse({ status: 404, description: 'Application not found' })
   async remove(
     @Param('uuid') uuid: string,
     @CurrentUser() user: JwtPayload,

--- a/src/modules/applications/dto/application-response.dto.ts
+++ b/src/modules/applications/dto/application-response.dto.ts
@@ -1,8 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class ApplicationResponseDto {
-  id!: string; // UUID
-  jobId!: string; // Job UUID
-  userId!: string; // Applicant UUID
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50', description: 'Application UUID' })
+  id!: string;
+
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f51', description: 'Job UUID' })
+  jobId!: string;
+
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f52', description: 'Applicant user UUID' })
+  userId!: string;
+
+  @ApiProperty({ example: 'pending', enum: ['pending', 'accepted', 'rejected'] })
   status!: string;
+
+  @ApiProperty()
   createdAt!: Date;
+
+  @ApiProperty()
   updatedAt!: Date;
 }

--- a/src/modules/applications/dto/create-application.dto.ts
+++ b/src/modules/applications/dto/create-application.dto.ts
@@ -1,6 +1,8 @@
 import { IsNotEmpty, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateApplicationDto {
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50', description: 'UUID of the job to apply to' })
   @IsUUID('4')
   @IsNotEmpty()
   jobId!: string;

--- a/src/modules/applications/dto/update-application-status.dto.ts
+++ b/src/modules/applications/dto/update-application-status.dto.ts
@@ -1,4 +1,5 @@
 import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export const APPLICATION_STATUSES = [
   'pending',
@@ -8,6 +9,7 @@ export const APPLICATION_STATUSES = [
 export type ApplicationStatus = (typeof APPLICATION_STATUSES)[number];
 
 export class UpdateApplicationStatusDto {
+  @ApiProperty({ example: 'accepted', enum: APPLICATION_STATUSES, description: 'New status for the application' })
   @IsString()
   @IsNotEmpty()
   @IsIn(APPLICATION_STATUSES)

--- a/src/modules/authentications/authentications.controller.ts
+++ b/src/modules/authentications/authentications.controller.ts
@@ -8,6 +8,12 @@ import {
   Put,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { AuthenticationsService } from './authentications.service';
 import { LoginDto } from './dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
@@ -16,6 +22,7 @@ import { THROTTLER_LIMITS } from '../../common/constants/throttler.constants';
 import { SkipTransform } from '../../common/decorators/skip-transform.decorator';
 import type { TokenPair, AccessTokenResponse } from './authentications.service';
 
+@ApiTags('Authentications')
 @Controller('authentications')
 export class AuthenticationsController {
   constructor(
@@ -25,6 +32,10 @@ export class AuthenticationsController {
   @Post()
   @HttpCode(HttpStatus.CREATED)
   @Throttle({ default: THROTTLER_LIMITS.moderate })
+  @ApiOperation({ summary: 'Login and obtain JWT token pair' })
+  @ApiBody({ type: LoginDto })
+  @ApiResponse({ status: 201, description: 'Login successful — returns access & refresh tokens' })
+  @ApiResponse({ status: 401, description: 'Invalid credentials' })
   async login(@Body() dto: LoginDto): Promise<TokenPair> {
     return this.authenticationsService.login(dto);
   }
@@ -32,6 +43,10 @@ export class AuthenticationsController {
   @Put()
   @HttpCode(HttpStatus.OK)
   @Throttle({ default: THROTTLER_LIMITS.moderate })
+  @ApiOperation({ summary: 'Refresh access token using a refresh token' })
+  @ApiBody({ type: RefreshTokenDto })
+  @ApiResponse({ status: 200, description: 'Returns a new access token' })
+  @ApiResponse({ status: 401, description: 'Invalid or expired refresh token' })
   async refresh(@Body() dto: RefreshTokenDto): Promise<AccessTokenResponse> {
     return this.authenticationsService.refresh(dto);
   }
@@ -39,6 +54,9 @@ export class AuthenticationsController {
   @Delete()
   @HttpCode(HttpStatus.OK)
   @SkipTransform()
+  @ApiOperation({ summary: 'Logout and invalidate refresh token' })
+  @ApiBody({ type: LogoutDto })
+  @ApiResponse({ status: 200, description: 'Logout successful' })
   async logout(
     @Body() dto: LogoutDto,
   ): Promise<{ status: string; message: string }> {

--- a/src/modules/authentications/dto/login.dto.ts
+++ b/src/modules/authentications/dto/login.dto.ts
@@ -1,10 +1,13 @@
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LoginDto {
+  @ApiProperty({ example: 'user@example.com', description: 'User email address' })
   @IsEmail()
   @IsNotEmpty()
   email!: string;
 
+  @ApiProperty({ example: 'password123', description: 'User password (min 8 characters)' })
   @IsString()
   @IsNotEmpty()
   password!: string;

--- a/src/modules/authentications/dto/logout.dto.ts
+++ b/src/modules/authentications/dto/logout.dto.ts
@@ -1,6 +1,8 @@
 import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class LogoutDto {
+  @ApiProperty({ description: 'Refresh token to invalidate' })
   @IsString()
   @IsNotEmpty()
   refreshToken!: string;

--- a/src/modules/authentications/dto/refresh-token.dto.ts
+++ b/src/modules/authentications/dto/refresh-token.dto.ts
@@ -1,6 +1,8 @@
 import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class RefreshTokenDto {
+  @ApiProperty({ description: 'Refresh token issued at login' })
   @IsString()
   @IsNotEmpty()
   refreshToken!: string;

--- a/src/modules/bookmarks/bookmarks.controller.ts
+++ b/src/modules/bookmarks/bookmarks.controller.ts
@@ -10,6 +10,15 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiHeader,
+} from '@nestjs/swagger';
 import type { Response } from 'express';
 import { BookmarksService } from './bookmarks.service';
 import { BookmarkResponseDto } from './dto/bookmark-response.dto';
@@ -22,6 +31,8 @@ import {
   type PaginatedResult,
 } from '../profile/dto/pagination-query.dto';
 
+@ApiTags('Bookmarks')
+@ApiBearerAuth('access-token')
 @Controller()
 export class BookmarksController {
   constructor(private readonly bookmarksService: BookmarksService) {}
@@ -29,6 +40,10 @@ export class BookmarksController {
   @Post('jobs/:jobId/bookmark')
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Bookmark a job' })
+  @ApiParam({ name: 'jobId', description: 'Job UUID' })
+  @ApiResponse({ status: 201, description: 'Job bookmarked', type: BookmarkResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   create(
     @CurrentUser() user: JwtPayload,
     @Param('jobId') jobId: string,
@@ -40,6 +55,10 @@ export class BookmarksController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
   @SkipTransform()
+  @ApiOperation({ summary: 'Remove a job bookmark' })
+  @ApiParam({ name: 'jobId', description: 'Job UUID' })
+  @ApiResponse({ status: 200, description: 'Bookmark removed' })
+  @ApiResponse({ status: 404, description: 'Bookmark not found' })
   async remove(
     @CurrentUser() user: JwtPayload,
     @Param('jobId') jobId: string,
@@ -50,6 +69,11 @@ export class BookmarksController {
 
   @Get('jobs/:jobId/bookmark/:id')
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Get a specific bookmark by UUID' })
+  @ApiParam({ name: 'jobId', description: 'Job UUID' })
+  @ApiParam({ name: 'id', description: 'Bookmark UUID' })
+  @ApiResponse({ status: 200, description: 'Bookmark found', type: BookmarkResponseDto })
+  @ApiResponse({ status: 404, description: 'Bookmark not found' })
   findOne(
     @CurrentUser() user: JwtPayload,
     @Param('jobId') jobId: string,
@@ -60,6 +84,11 @@ export class BookmarksController {
 
   @Get('bookmarks')
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'List all bookmarks for the current user (paginated)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiHeader({ name: 'X-Data-Source', required: false, description: 'cache | database' })
+  @ApiResponse({ status: 200, description: 'Paginated list of bookmarks' })
   async getAll(
     @CurrentUser() user: JwtPayload,
     @Query() query: PaginationQueryDto,

--- a/src/modules/bookmarks/dto/bookmark-response.dto.ts
+++ b/src/modules/bookmarks/dto/bookmark-response.dto.ts
@@ -1,7 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class BookmarkResponseDto {
-  id!: string; // UUID
-  jobId!: string; // Job UUID
-  userId!: string; // User UUID
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50', description: 'Bookmark UUID' })
+  id!: string;
+
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f51', description: 'Job UUID' })
+  jobId!: string;
+
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f52', description: 'User UUID' })
+  userId!: string;
+
+  @ApiProperty()
   createdAt!: Date;
+
+  @ApiProperty()
   updatedAt!: Date;
 }

--- a/src/modules/categories/categories.controller.ts
+++ b/src/modules/categories/categories.controller.ts
@@ -12,6 +12,15 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiHeader,
+} from '@nestjs/swagger';
 import type { Response } from 'express';
 import { CategoriesService } from './categories.service';
 import { CreateCategoryDto } from './dto/create-category.dto';
@@ -24,11 +33,16 @@ import {
   type PaginatedResult,
 } from '../profile/dto/pagination-query.dto';
 
+@ApiTags('Categories')
 @Controller('categories')
 export class CategoriesController {
   constructor(private readonly categoriesService: CategoriesService) {}
 
   @Get()
+  @ApiOperation({ summary: 'List all categories (paginated)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated list of categories' })
   getAll(
     @Query() query: PaginationQueryDto,
   ): Promise<PaginatedResult<CategoryResponseDto>> {
@@ -36,6 +50,11 @@ export class CategoriesController {
   }
 
   @Get(':uuid')
+  @ApiOperation({ summary: 'Get a category by UUID' })
+  @ApiParam({ name: 'uuid', description: 'Category UUID' })
+  @ApiHeader({ name: 'X-Data-Source', required: false, description: 'cache | database' })
+  @ApiResponse({ status: 200, description: 'Category found', type: CategoryResponseDto })
+  @ApiResponse({ status: 404, description: 'Category not found' })
   async getById(
     @Param('uuid') uuid: string,
     @Res({ passthrough: true }) res: Response,
@@ -48,6 +67,10 @@ export class CategoriesController {
   @Post()
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Create a new category (admin)' })
+  @ApiResponse({ status: 201, description: 'Category created', type: CategoryResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   create(@Body() dto: CreateCategoryDto): Promise<CategoryResponseDto> {
     return this.categoriesService.create(dto);
   }
@@ -56,6 +79,11 @@ export class CategoriesController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
   @SkipTransform()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Update a category' })
+  @ApiParam({ name: 'uuid', description: 'Category UUID' })
+  @ApiResponse({ status: 200, description: 'Category updated successfully' })
+  @ApiResponse({ status: 404, description: 'Category not found' })
   async update(
     @Param('uuid') uuid: string,
     @Body() dto: UpdateCategoryDto,
@@ -68,6 +96,11 @@ export class CategoriesController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
   @SkipTransform()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Delete (soft-delete) a category' })
+  @ApiParam({ name: 'uuid', description: 'Category UUID' })
+  @ApiResponse({ status: 200, description: 'Category deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Category not found' })
   async remove(
     @Param('uuid') uuid: string,
   ): Promise<{ status: string; message: string }> {

--- a/src/modules/categories/dto/category-response.dto.ts
+++ b/src/modules/categories/dto/category-response.dto.ts
@@ -1,6 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class CategoryResponseDto {
-  id!: string; // UUID
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50', description: 'Category UUID' })
+  id!: string;
+
+  @ApiProperty({ example: 'Software Engineering' })
   name!: string;
+
+  @ApiProperty()
   createdAt!: Date;
+
+  @ApiProperty()
   updatedAt!: Date;
 }

--- a/src/modules/categories/dto/create-category.dto.ts
+++ b/src/modules/categories/dto/create-category.dto.ts
@@ -1,6 +1,8 @@
 import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateCategoryDto {
+  @ApiProperty({ example: 'Software Engineering', maxLength: 100 })
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)

--- a/src/modules/categories/dto/update-category.dto.ts
+++ b/src/modules/categories/dto/update-category.dto.ts
@@ -1,6 +1,8 @@
 import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateCategoryDto {
+  @ApiPropertyOptional({ example: 'Data Engineering', maxLength: 100 })
   @IsOptional()
   @IsString()
   @IsNotEmpty()

--- a/src/modules/companies/companies.controller.ts
+++ b/src/modules/companies/companies.controller.ts
@@ -12,6 +12,15 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiHeader,
+} from '@nestjs/swagger';
 import type { Response } from 'express';
 import { CompaniesService } from './companies.service';
 import { CreateCompanyDto } from './dto/create-company.dto';
@@ -26,11 +35,16 @@ import {
   type PaginatedResult,
 } from '../profile/dto/pagination-query.dto';
 
+@ApiTags('Companies')
 @Controller('companies')
 export class CompaniesController {
   constructor(private readonly companiesService: CompaniesService) {}
 
   @Get()
+  @ApiOperation({ summary: 'List all companies (paginated)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated list of companies' })
   getAll(
     @Query() query: PaginationQueryDto,
   ): Promise<PaginatedResult<CompanyResponseDto>> {
@@ -38,6 +52,11 @@ export class CompaniesController {
   }
 
   @Get(':uuid')
+  @ApiOperation({ summary: 'Get a company by UUID' })
+  @ApiParam({ name: 'uuid', description: 'Company UUID' })
+  @ApiHeader({ name: 'X-Data-Source', required: false, description: 'cache | database' })
+  @ApiResponse({ status: 200, description: 'Company found', type: CompanyResponseDto })
+  @ApiResponse({ status: 404, description: 'Company not found' })
   async getById(
     @Param('uuid') uuid: string,
     @Res({ passthrough: true }) res: Response,
@@ -50,6 +69,10 @@ export class CompaniesController {
   @Post()
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Create a new company' })
+  @ApiResponse({ status: 201, description: 'Company created', type: CompanyResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   create(
     @CurrentUser() user: JwtPayload,
     @Body() dto: CreateCompanyDto,
@@ -61,6 +84,12 @@ export class CompaniesController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
   @SkipTransform()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Update a company' })
+  @ApiParam({ name: 'uuid', description: 'Company UUID' })
+  @ApiResponse({ status: 200, description: 'Company updated successfully' })
+  @ApiResponse({ status: 403, description: 'Forbidden — not the owner' })
+  @ApiResponse({ status: 404, description: 'Company not found' })
   async update(
     @Param('uuid') uuid: string,
     @CurrentUser() user: JwtPayload,
@@ -74,6 +103,12 @@ export class CompaniesController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
   @SkipTransform()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Delete (soft-delete) a company' })
+  @ApiParam({ name: 'uuid', description: 'Company UUID' })
+  @ApiResponse({ status: 200, description: 'Company deleted successfully' })
+  @ApiResponse({ status: 403, description: 'Forbidden — not the owner' })
+  @ApiResponse({ status: 404, description: 'Company not found' })
   async remove(
     @Param('uuid') uuid: string,
     @CurrentUser() user: JwtPayload,

--- a/src/modules/companies/dto/company-response.dto.ts
+++ b/src/modules/companies/dto/company-response.dto.ts
@@ -1,9 +1,24 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
 export class CompanyResponseDto {
-  id!: string; // UUID
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50', description: 'Company UUID' })
+  id!: string;
+
+  @ApiProperty({ example: 'Acme Corp' })
   name!: string;
+
+  @ApiPropertyOptional({ example: 'A leading tech company', nullable: true })
   description!: string | null;
+
+  @ApiProperty({ example: 'Jakarta, Indonesia' })
   location!: string;
-  userId!: string; // Owner UUID
+
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f51', description: 'Owner user UUID' })
+  userId!: string;
+
+  @ApiProperty()
   createdAt!: Date;
+
+  @ApiProperty()
   updatedAt!: Date;
 }

--- a/src/modules/companies/dto/create-company.dto.ts
+++ b/src/modules/companies/dto/create-company.dto.ts
@@ -1,15 +1,19 @@
 import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateCompanyDto {
+  @ApiProperty({ example: 'Acme Corp', maxLength: 150 })
   @IsString()
   @IsNotEmpty()
   @MaxLength(150)
   name!: string;
 
+  @ApiPropertyOptional({ example: 'A leading tech company' })
   @IsString()
   @IsOptional()
   description?: string;
 
+  @ApiProperty({ example: 'Jakarta, Indonesia', maxLength: 150 })
   @IsString()
   @IsNotEmpty()
   @MaxLength(150)

--- a/src/modules/companies/dto/update-company.dto.ts
+++ b/src/modules/companies/dto/update-company.dto.ts
@@ -1,15 +1,19 @@
 import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateCompanyDto {
+  @ApiPropertyOptional({ example: 'Acme Corp', maxLength: 150 })
   @IsString()
   @IsOptional()
   @MaxLength(150)
   name?: string;
 
+  @ApiPropertyOptional({ example: 'A leading tech company' })
   @IsString()
   @IsOptional()
   description?: string;
 
+  @ApiPropertyOptional({ example: 'Bandung, Indonesia', maxLength: 150 })
   @IsString()
   @IsOptional()
   @MaxLength(150)

--- a/src/modules/documents/documents.controller.ts
+++ b/src/modules/documents/documents.controller.ts
@@ -14,6 +14,17 @@ import {
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { memoryStorage } from 'multer';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiHeader,
+  ApiConsumes,
+  ApiBody,
+} from '@nestjs/swagger';
 import type { Response } from 'express';
 import { DocumentsService } from './documents.service';
 import { DocumentResponseDto } from './dto/document-response.dto';
@@ -26,6 +37,7 @@ import {
   type PaginatedResult,
 } from '../profile/dto/pagination-query.dto';
 
+@ApiTags('Documents')
 @Controller('documents')
 export class DocumentsController {
   constructor(private readonly documentsService: DocumentsService) {}
@@ -34,6 +46,20 @@ export class DocumentsController {
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(JwtAuthGuard)
   @UseInterceptors(FileInterceptor('file', { storage: memoryStorage() }))
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Upload a PDF resume/document (max 5MB)' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        file: { type: 'string', format: 'binary', description: 'PDF file (max 5MB)' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Document uploaded', type: DocumentResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid file type or size' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   upload(
     @CurrentUser() user: JwtPayload,
     @UploadedFile() file: Express.Multer.File,
@@ -42,6 +68,10 @@ export class DocumentsController {
   }
 
   @Get()
+  @ApiOperation({ summary: 'List all documents (paginated)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated list of documents' })
   getAll(
     @Query() query: PaginationQueryDto,
   ): Promise<PaginatedResult<DocumentResponseDto>> {
@@ -49,6 +79,11 @@ export class DocumentsController {
   }
 
   @Get(':uuid')
+  @ApiOperation({ summary: 'Get a document by UUID' })
+  @ApiParam({ name: 'uuid', description: 'Document UUID' })
+  @ApiHeader({ name: 'X-Data-Source', required: false, description: 'cache | database' })
+  @ApiResponse({ status: 200, description: 'Document found', type: DocumentResponseDto })
+  @ApiResponse({ status: 404, description: 'Document not found' })
   async getById(
     @Param('uuid') uuid: string,
     @Res({ passthrough: true }) res: Response,
@@ -62,6 +97,12 @@ export class DocumentsController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
   @SkipTransform()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Delete a document' })
+  @ApiParam({ name: 'uuid', description: 'Document UUID' })
+  @ApiResponse({ status: 200, description: 'Document deleted successfully' })
+  @ApiResponse({ status: 403, description: 'Forbidden — not the owner' })
+  @ApiResponse({ status: 404, description: 'Document not found' })
   async remove(
     @Param('uuid') uuid: string,
     @CurrentUser() user: JwtPayload,

--- a/src/modules/documents/dto/document-response.dto.ts
+++ b/src/modules/documents/dto/document-response.dto.ts
@@ -1,10 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class DocumentResponseDto {
-  id!: string; // UUID
-  userId!: string; // User UUID
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50', description: 'Document UUID' })
+  id!: string;
+
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f51', description: 'Owner user UUID' })
+  userId!: string;
+
+  @ApiProperty({ example: 'my-resume.pdf' })
   originalName!: string;
+
+  @ApiProperty({ example: 'application/pdf' })
   mimeType!: string;
+
+  @ApiProperty({ example: 204800, description: 'File size in bytes' })
   size!: number;
+
+  @ApiProperty({ example: 'https://s3.example.com/bucket/uuid.pdf?X-Amz-Signature=...', description: 'Pre-signed S3 URL' })
   presignedUrl!: string;
+
+  @ApiProperty()
   createdAt!: Date;
+
+  @ApiProperty()
   updatedAt!: Date;
 }

--- a/src/modules/jobs/dto/create-job.dto.ts
+++ b/src/modules/jobs/dto/create-job.dto.ts
@@ -7,35 +7,43 @@ import {
   MaxLength,
   Min,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateJobDto {
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50', description: 'Company UUID' })
   @IsUUID()
   @IsNotEmpty()
   companyId!: string;
 
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f51', description: 'Category UUID' })
   @IsUUID()
   @IsNotEmpty()
   categoryId!: string;
 
+  @ApiProperty({ example: 'Backend Engineer', maxLength: 200 })
   @IsString()
   @IsNotEmpty()
   @MaxLength(200)
   title!: string;
 
+  @ApiPropertyOptional({ example: 'We are looking for a skilled backend engineer...' })
   @IsString()
   @IsOptional()
   description?: string;
 
+  @ApiPropertyOptional({ example: 'Jakarta, Indonesia', maxLength: 150 })
   @IsString()
   @IsOptional()
   @MaxLength(150)
   location?: string;
 
+  @ApiPropertyOptional({ example: 15000000, minimum: 0, description: 'Salary in IDR' })
   @IsNumber()
   @IsOptional()
   @Min(0)
   salary?: number;
 
+  @ApiProperty({ example: 'Full-time', maxLength: 50 })
   @IsString()
   @IsNotEmpty()
   @MaxLength(50)

--- a/src/modules/jobs/dto/job-query.dto.ts
+++ b/src/modules/jobs/dto/job-query.dto.ts
@@ -1,13 +1,16 @@
 import { IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { PaginationQueryDto } from '../../profile/dto/pagination-query.dto';
 
 export class JobQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({ example: 'Backend Engineer', description: 'Filter by job title (partial match)' })
   @IsOptional()
   @IsString()
   title?: string;
 
   // Populated by companyNameQueryMiddleware in JobsModule, which remaps
   // ?company-name → ?companyName before the global ValidationPipe runs.
+  @ApiPropertyOptional({ name: 'company-name', example: 'Acme Corp', description: 'Filter by company name (partial match)' })
   @IsOptional()
   @IsString()
   companyName?: string;

--- a/src/modules/jobs/dto/job-response.dto.ts
+++ b/src/modules/jobs/dto/job-response.dto.ts
@@ -1,15 +1,35 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { CompanyResponseDto } from '../../companies/dto/company-response.dto';
 import type { CategoryResponseDto } from '../../categories/dto/category-response.dto';
 
 export class JobResponseDto {
-  id!: string; // UUID
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50', description: 'Job UUID' })
+  id!: string;
+
+  @ApiProperty({ example: 'Backend Engineer' })
   title!: string;
+
+  @ApiPropertyOptional({ example: 'We are looking for a skilled backend engineer...', nullable: true })
   description!: string | null;
+
+  @ApiPropertyOptional({ example: 'Jakarta, Indonesia', nullable: true })
   location!: string | null;
+
+  @ApiPropertyOptional({ example: 15000000, nullable: true })
   salary!: number | null;
+
+  @ApiProperty({ example: 'Full-time' })
   type!: string;
+
+  @ApiProperty({ description: 'Company information' })
   company!: CompanyResponseDto;
+
+  @ApiProperty({ description: 'Category information' })
   category!: CategoryResponseDto;
+
+  @ApiProperty()
   createdAt!: Date;
+
+  @ApiProperty()
   updatedAt!: Date;
 }

--- a/src/modules/jobs/dto/update-job.dto.ts
+++ b/src/modules/jobs/dto/update-job.dto.ts
@@ -5,27 +5,33 @@ import {
   MaxLength,
   Min,
 } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateJobDto {
+  @ApiPropertyOptional({ example: 'Senior Backend Engineer', maxLength: 200 })
   @IsString()
   @IsOptional()
   @MaxLength(200)
   title?: string;
 
+  @ApiPropertyOptional({ example: 'We are looking for a senior backend engineer...' })
   @IsString()
   @IsOptional()
   description?: string;
 
+  @ApiPropertyOptional({ example: 'Bandung, Indonesia', maxLength: 150 })
   @IsString()
   @IsOptional()
   @MaxLength(150)
   location?: string;
 
+  @ApiPropertyOptional({ example: 20000000, minimum: 0 })
   @IsNumber()
   @IsOptional()
   @Min(0)
   salary?: number;
 
+  @ApiPropertyOptional({ example: 'Part-time', maxLength: 50 })
   @IsString()
   @IsOptional()
   @MaxLength(50)

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -13,6 +13,15 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+  ApiHeader,
+} from '@nestjs/swagger';
 import type { Response } from 'express';
 import { JobsService } from './jobs.service';
 import { CreateJobDto } from './dto/create-job.dto';
@@ -28,11 +37,18 @@ import {
   type PaginatedResult,
 } from '../profile/dto/pagination-query.dto';
 
+@ApiTags('Jobs')
 @Controller('jobs')
 export class JobsController {
   constructor(private readonly jobsService: JobsService) {}
 
   @Get()
+  @ApiOperation({ summary: 'List all jobs (paginated, filterable)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiQuery({ name: 'title', required: false, type: String, description: 'Filter by job title' })
+  @ApiQuery({ name: 'company-name', required: false, type: String, description: 'Filter by company name' })
+  @ApiResponse({ status: 200, description: 'Paginated list of jobs' })
   getAll(
     @Query() query: JobQueryDto,
   ): Promise<PaginatedResult<JobResponseDto>> {
@@ -42,6 +58,11 @@ export class JobsController {
   // NOTE: static-prefix routes must be declared before :uuid to avoid
   // NestJS / Express route-matching conflicts.
   @Get('company/:companyId')
+  @ApiOperation({ summary: 'List jobs by company UUID' })
+  @ApiParam({ name: 'companyId', description: 'Company UUID' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated list of jobs for the given company' })
   getByCompany(
     @Param('companyId', ParseUUIDPipe) companyId: string,
     @Query() query: PaginationQueryDto,
@@ -50,6 +71,11 @@ export class JobsController {
   }
 
   @Get('category/:categoryId')
+  @ApiOperation({ summary: 'List jobs by category UUID' })
+  @ApiParam({ name: 'categoryId', description: 'Category UUID' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated list of jobs for the given category' })
   getByCategory(
     @Param('categoryId', ParseUUIDPipe) categoryId: string,
     @Query() query: PaginationQueryDto,
@@ -58,6 +84,11 @@ export class JobsController {
   }
 
   @Get(':uuid')
+  @ApiOperation({ summary: 'Get a job by UUID' })
+  @ApiParam({ name: 'uuid', description: 'Job UUID' })
+  @ApiHeader({ name: 'X-Data-Source', required: false, description: 'cache | database' })
+  @ApiResponse({ status: 200, description: 'Job found', type: JobResponseDto })
+  @ApiResponse({ status: 404, description: 'Job not found' })
   async getById(
     @Param('uuid', ParseUUIDPipe) uuid: string,
     @Res({ passthrough: true }) res: Response,
@@ -70,6 +101,11 @@ export class JobsController {
   @Post()
   @HttpCode(HttpStatus.CREATED)
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Create a new job posting' })
+  @ApiResponse({ status: 201, description: 'Job created', type: JobResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — company not owned by user' })
   create(
     @CurrentUser() user: JwtPayload,
     @Body() dto: CreateJobDto,
@@ -81,6 +117,12 @@ export class JobsController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
   @SkipTransform()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Update a job posting' })
+  @ApiParam({ name: 'uuid', description: 'Job UUID' })
+  @ApiResponse({ status: 200, description: 'Job updated successfully' })
+  @ApiResponse({ status: 403, description: 'Forbidden — not the owner' })
+  @ApiResponse({ status: 404, description: 'Job not found' })
   async update(
     @Param('uuid', ParseUUIDPipe) uuid: string,
     @CurrentUser() user: JwtPayload,
@@ -94,6 +136,12 @@ export class JobsController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
   @SkipTransform()
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Delete (soft-delete) a job posting' })
+  @ApiParam({ name: 'uuid', description: 'Job UUID' })
+  @ApiResponse({ status: 200, description: 'Job deleted successfully' })
+  @ApiResponse({ status: 403, description: 'Forbidden — not the owner' })
+  @ApiResponse({ status: 404, description: 'Job not found' })
   async remove(
     @Param('uuid', ParseUUIDPipe) uuid: string,
     @CurrentUser() user: JwtPayload,

--- a/src/modules/profile/dto/pagination-query.dto.ts
+++ b/src/modules/profile/dto/pagination-query.dto.ts
@@ -1,13 +1,16 @@
 import { Type } from 'class-transformer';
 import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class PaginationQueryDto {
+  @ApiPropertyOptional({ example: 1, default: 1, minimum: 1, description: 'Page number' })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page: number = 1;
 
+  @ApiPropertyOptional({ example: 10, default: 10, minimum: 1, maximum: 100, description: 'Items per page' })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/src/modules/profile/dto/profile-application-response.dto.ts
+++ b/src/modules/profile/dto/profile-application-response.dto.ts
@@ -1,14 +1,32 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
 export class JobSummaryDto {
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50' })
   id!: string;
+
+  @ApiProperty({ example: 'Backend Engineer' })
   title!: string;
+
+  @ApiProperty({ example: 'Jakarta, Indonesia' })
   location!: string;
+
+  @ApiProperty({ example: 'Full-time' })
   type!: string;
+
+  @ApiPropertyOptional({ example: '15000000', nullable: true })
   salary!: string | null;
 }
 
 export class ProfileApplicationResponseDto {
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50' })
   id!: string;
+
+  @ApiProperty({ example: 'pending', enum: ['pending', 'accepted', 'rejected'] })
   status!: string;
+
+  @ApiProperty()
   createdAt!: Date;
+
+  @ApiProperty({ type: () => JobSummaryDto })
   job!: JobSummaryDto;
 }

--- a/src/modules/profile/dto/profile-bookmark-response.dto.ts
+++ b/src/modules/profile/dto/profile-bookmark-response.dto.ts
@@ -1,7 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { JobSummaryDto } from './profile-application-response.dto';
 
 export class ProfileBookmarkResponseDto {
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50' })
   id!: string;
+
+  @ApiProperty()
   createdAt!: Date;
+
+  @ApiProperty({ type: () => JobSummaryDto })
   job!: JobSummaryDto;
 }

--- a/src/modules/profile/profile.controller.ts
+++ b/src/modules/profile/profile.controller.ts
@@ -1,4 +1,11 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiQuery,
+} from '@nestjs/swagger';
 import { ProfileService } from './profile.service';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 import type { JwtPayload } from '../../common/guards/jwt-auth.guard';
@@ -11,17 +18,26 @@ import {
 import { ProfileApplicationResponseDto } from './dto/profile-application-response.dto';
 import { ProfileBookmarkResponseDto } from './dto/profile-bookmark-response.dto';
 
+@ApiTags('Profile')
+@ApiBearerAuth('access-token')
 @UseGuards(JwtAuthGuard)
 @Controller('profile')
 export class ProfileController {
   constructor(private readonly profileService: ProfileService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Get the authenticated user\'s profile' })
+  @ApiResponse({ status: 200, description: 'User profile', type: UserResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   getProfile(@CurrentUser() user: JwtPayload): Promise<UserResponseDto> {
     return this.profileService.getProfile(user.id);
   }
 
   @Get('applications')
+  @ApiOperation({ summary: 'Get the authenticated user\'s job applications (paginated)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated list of applications' })
   getApplications(
     @CurrentUser() user: JwtPayload,
     @Query() query: PaginationQueryDto,
@@ -30,6 +46,10 @@ export class ProfileController {
   }
 
   @Get('bookmarks')
+  @ApiOperation({ summary: 'Get the authenticated user\'s bookmarked jobs (paginated)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated list of bookmarks' })
   getBookmarks(
     @CurrentUser() user: JwtPayload,
     @Query() query: PaginationQueryDto,

--- a/src/modules/users/dto/create-user.dto.ts
+++ b/src/modules/users/dto/create-user.dto.ts
@@ -5,18 +5,22 @@ import {
   MinLength,
   MaxLength,
 } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateUserDto {
+  @ApiProperty({ example: 'John Doe', maxLength: 100, description: 'Full name of the user' })
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)
   fullname!: string;
 
+  @ApiProperty({ example: 'john.doe@example.com', maxLength: 150, description: 'User email address' })
   @IsEmail()
   @IsNotEmpty()
   @MaxLength(150)
   email!: string;
 
+  @ApiProperty({ example: 'securePass1', minLength: 8, description: 'Password (min 8 characters)' })
   @IsString()
   @IsNotEmpty()
   @MinLength(8)

--- a/src/modules/users/dto/user-response.dto.ts
+++ b/src/modules/users/dto/user-response.dto.ts
@@ -1,7 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
 export class UserResponseDto {
-  id!: string; // UUID — exposed as public identifier
+  @ApiProperty({ example: '01935b1c-a3d4-7c5e-8f9a-0b1c2d3e4f50', description: 'User UUID (public identifier)' })
+  id!: string;
+
+  @ApiProperty({ example: 'John Doe' })
   fullname!: string;
+
+  @ApiProperty({ example: 'john.doe@example.com' })
   email!: string;
+
+  @ApiProperty()
   createdAt!: Date;
+
+  @ApiProperty()
   updatedAt!: Date;
 }

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -9,12 +9,21 @@ import {
   Res,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiParam,
+  ApiHeader,
+} from '@nestjs/swagger';
 import type { Response } from 'express';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UserResponseDto } from './dto/user-response.dto';
 import { THROTTLER_LIMITS } from '../../common/constants/throttler.constants';
 
+@ApiTags('Users')
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
@@ -22,11 +31,21 @@ export class UsersController {
   @Post()
   @HttpCode(HttpStatus.CREATED)
   @Throttle({ default: THROTTLER_LIMITS.strict })
+  @ApiOperation({ summary: 'Register a new user account' })
+  @ApiBody({ type: CreateUserDto })
+  @ApiResponse({ status: 201, description: 'User registered successfully', type: UserResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  @ApiResponse({ status: 409, description: 'Email already in use' })
   async register(@Body() dto: CreateUserDto): Promise<UserResponseDto> {
     return this.usersService.create(dto);
   }
 
   @Get(':uuid')
+  @ApiOperation({ summary: 'Get user by UUID' })
+  @ApiParam({ name: 'uuid', description: 'User UUID' })
+  @ApiHeader({ name: 'X-Data-Source', required: false, description: 'cache | database' })
+  @ApiResponse({ status: 200, description: 'User found', type: UserResponseDto })
+  @ApiResponse({ status: 404, description: 'User not found' })
   async getProfile(
     @Param('uuid') uuid: string,
     @Res({ passthrough: true }) res: Response,


### PR DESCRIPTION
## Summary

Closes #18

Integrates `@nestjs/swagger` to provide interactive API documentation accessible at `GET /api/docs`, matching the contract defined in `docs/api/api-spec.yaml`.

---

## Changes

### `src/main.ts`
- Configured `DocumentBuilder` with title, description, version, and `BearerAuth` scheme (`access-token`)
- Mounted Swagger UI at `/api/docs` with `persistAuthorization: true`

### DTOs — added `@ApiProperty` / `@ApiPropertyOptional`
- `authentications`: `login.dto.ts`, `logout.dto.ts`, `refresh-token.dto.ts`
- `users`: `create-user.dto.ts`, `user-response.dto.ts`
- `companies`: `create-company.dto.ts`, `update-company.dto.ts`, `company-response.dto.ts`
- `categories`: `create-category.dto.ts`, `update-category.dto.ts`, `category-response.dto.ts`
- `jobs`: `create-job.dto.ts`, `update-job.dto.ts`, `job-response.dto.ts`, `job-query.dto.ts`
- `applications`: `create-application.dto.ts`, `update-application-status.dto.ts`, `application-response.dto.ts`
- `bookmarks`: `bookmark-response.dto.ts`
- `documents`: `document-response.dto.ts`
- `profile`: `pagination-query.dto.ts`, `profile-application-response.dto.ts`, `profile-bookmark-response.dto.ts`

### Controllers — added `@ApiTags`, `@ApiOperation`, `@ApiResponse`, `@ApiBearerAuth`, `@ApiParam`, `@ApiQuery`, `@ApiHeader`
- `authentications.controller.ts`
- `users.controller.ts`
- `companies.controller.ts`
- `categories.controller.ts`
- `jobs.controller.ts`
- `applications.controller.ts`
- `bookmarks.controller.ts`
- `documents.controller.ts` (includes `@ApiConsumes('multipart/form-data')` + `@ApiBody` for file upload)
- `profile.controller.ts`

---

## Test Results

| Suite | Result |
|---|---|
| Unit Tests | ✅ 331/331 passed (28 suites) |
| E2E Tests | ✅ 174/174 passed (12 suites) |
