### PR TITLE
ci(release): GitHub Actions workflow to build & publish Docker image to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Build & Publish Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create GitHub Release + upload assets
+      packages: write   # push to GHCR
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Extracts semver tags + :latest label for the image
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # GitHub Actions cache to speed up subsequent releases
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          body: |
+            ## Docker Image
+
+            ```bash
+            docker pull ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ```
+
+            > Requires all env vars from `.env.example` to be supplied at runtime.
+            > Run `prisma migrate deploy` as a pre-deploy step before starting the container.


### PR DESCRIPTION
## 🔗 Closes
<!-- No issue — prerequisite for v1.0.0 release tag -->

---

## 📋 Summary

Adds `.github/workflows/release.yml` yang trigger otomatis saat tag `v*.*.*` di-push ke master.

**Flow:**
1. `docker/metadata-action` → extract semver tags (`v1.0.0`, `1.0`, `latest`)
2. `docker/build-push-action` → build multi-stage Dockerfile, push ke `ghcr.io/gilangheavy/open-job`
3. `softprops/action-gh-release` → buat GitHub Release dengan auto-generated release notes + docker pull instructions

**Auth:** menggunakan `GITHUB_TOKEN` bawaan — tidak perlu secrets tambahan.
**Cache:** menggunakan GitHub Actions cache (`type=gha`) untuk mempercepat build berikutnya.

---

## 🔄 Type of Change
- [x] `chore` — Setup, configuration, tooling

---

## 🧪 How to Test

Setelah PR ini merge, push tag `v1.0.0`:
```bash
git tag v1.0.0
git push origin v1.0.0
```

Cek:
- Actions tab → `Release` workflow berjalan
- https://github.com/gilangheavy/open-job/packages → image tersedia
- https://github.com/gilangheavy/open-job/releases → release v1.0.0 terbuat otomatis

---

## 🔍 Reviewer Checklist
- [x] No hardcoded credentials (uses `GITHUB_TOKEN`)
- [x] Workflow only triggers on semver tags, not on every push
